### PR TITLE
feat(dev): make app + hot-reload .app bundle for macOS development

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -4,7 +4,7 @@ root = "."
 tmp_dir = ".air_tmp"
 
 [build]
-  cmd      = "CGO_ENABLED=1 go build -ldflags \"-X github.com/ms/amplifier-app-loom/internal/api.Version=dev -s -w\" -o dist/loom ./cmd/loom/"
+  cmd      = "CGO_ENABLED=1 go build -ldflags \"-X github.com/ms/amplifier-app-loom/internal/api.Version=99.0.0-dev -s -w\" -o dist/loom ./cmd/loom/"
   bin      = "dist/loom"
   full_bin = "make app-sync"
 

--- a/.air.toml
+++ b/.air.toml
@@ -4,9 +4,9 @@ root = "."
 tmp_dir = ".air_tmp"
 
 [build]
-  cmd     = "go build -ldflags \"-X github.com/ms/amplifier-app-loom/internal/api.Version=dev -s -w\" -o dist/loom ./cmd/loom/"
-  bin     = "dist/loom"
-  args_bin = ["_serve"]
+  cmd      = "CGO_ENABLED=1 go build -ldflags \"-X github.com/ms/amplifier-app-loom/internal/api.Version=dev -s -w\" -o dist/loom ./cmd/loom/"
+  bin      = "dist/loom"
+  full_bin = "make app-sync"
 
   # Watch these extensions
   include_ext = ["go", "mod", "sum"]

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ run: build
 # make app-sync — fast path used by air: drop new binary → re-sign → relaunch
 # make dev      — bootstrap Loom.app then watch: .go save → rebuild → relaunch
 
-app: build
+app: ui $(DIST)
+	CGO_ENABLED=1 go build -ldflags "-X $(MODULE)/internal/api.Version=99.0.0-dev -s -w" -o $(DIST)/$(BINARY) ./cmd/loom/
 	@rm -rf dist/Loom.app
 	@mkdir -p dist/Loom.app/Contents/MacOS dist/Loom.app/Contents/Resources
 	@cp dist/loom dist/Loom.app/Contents/MacOS/loom

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ MODULE   = github.com/ms/amplifier-app-loom
 VERSION  = 0.8.5
 LDFLAGS  = -ldflags "-X $(MODULE)/internal/api.Version=$(VERSION) -s -w"
 
-.PHONY: build run install-svc uninstall-svc test clean cross ui release dev dev-go dev-ui
+.PHONY: build run install-svc uninstall-svc test clean cross ui release dev dev-go dev-ui app app-sync
 
 ui:
 	cd ui && npm install && npm run build
@@ -22,19 +22,46 @@ run: build
 
 # ── Development: hot-reload Go (air) + Vite dev server in parallel ────────
 # Browse http://localhost:5173  →  Vite proxies /api + /ws → Go at :7700
-# Uses make -j2 so each process runs directly with its own stdout — no
-# subshell buffering, no silent background jobs.
+#
+# make app      — full build + assemble dist/Loom.app + ad-hoc sign + launch
+# make app-sync — fast path used by air: drop new binary → re-sign → relaunch
+# make dev      — bootstrap Loom.app then watch: .go save → rebuild → relaunch
+
+app: build
+	@rm -rf dist/Loom.app
+	@mkdir -p dist/Loom.app/Contents/MacOS dist/Loom.app/Contents/Resources
+	@cp dist/loom dist/Loom.app/Contents/MacOS/loom
+	@sed 's/{{VERSION}}/dev/g' packaging/macos/Info.plist > dist/Loom.app/Contents/Info.plist
+	@cp packaging/macos/Loom.icns dist/Loom.app/Contents/Resources/ 2>/dev/null || true
+	@codesign --force --deep --sign - dist/Loom.app
+	@xattr -cr dist/Loom.app
+	@open dist/Loom.app
+	@printf "\033[32m→ dist/Loom.app launched\033[0m\n"
+
+app-sync:
+	@pkill -f "dist/Loom.app/Contents/MacOS/loom" 2>/dev/null || true
+	@sleep 0.3
+	@cp dist/loom dist/Loom.app/Contents/MacOS/loom
+	@codesign --force --deep --sign - dist/Loom.app
+	@xattr -cr dist/Loom.app
+	@open dist/Loom.app
+	@printf "\033[32m→ Loom.app reloaded\033[0m\n"
+
 dev:
 	@mkdir -p $(DIST)
 	@if [ ! -f web/dist/index.html ]; then \
 		printf "\033[33m→ web/dist is empty — building UI assets first...\033[0m\n"; \
 		$(MAKE) ui; \
 	fi
+	@if [ ! -d dist/Loom.app ]; then \
+		printf "\033[33m→ building initial Loom.app...\033[0m\n"; \
+		$(MAKE) app; \
+	fi
 	@command -v air >/dev/null 2>&1 || (printf "\033[33m→ Installing air...\033[0m\n" && go install github.com/air-verse/air@latest)
 	@printf "\033[33m→ Stopping any running loom service...\033[0m\n"
 	@loom stop 2>/dev/null || true
 	@printf "\033[32m→ Dev environment starting:\033[0m\n"
-	@printf "  \033[36m•\033[0m Go hot-reload (air)    — .go changes rebuild → :7700\n"
+	@printf "  \033[36m•\033[0m Go hot-reload (air)    — .go save → rebuild → Loom.app relaunches\n"
 	@printf "  \033[36m•\033[0m Vite dev server         — http://localhost:5173\n\n"
 	@$(MAKE) -j2 dev-go dev-ui
 

--- a/internal/api/handlers_bundles.go
+++ b/internal/api/handlers_bundles.go
@@ -382,9 +382,19 @@ func (s *Server) getLocalRegistry(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data, err := os.ReadFile(filepath.Join(home, ".amplifier", "bundle-index", "index.json"))
-	if err != nil {
-		// Not initialised yet — return empty array, not an error.
+	// Prefer GitHub-based index (github-index.mjs) over local-filesystem index.
+	var data []byte
+	for _, rel := range []string{
+		filepath.Join(".amplifier", "github-bundle-index", "index.json"),
+		filepath.Join(".amplifier", "bundle-index", "index.json"),
+	} {
+		if b, e := os.ReadFile(filepath.Join(home, rel)); e == nil {
+			data = b
+			break
+		}
+	}
+	if data == nil {
+		// Neither index seeded yet — return empty, not an error.
 		writeJSON(w, http.StatusOK, []json.RawMessage{})
 		return
 	}

--- a/internal/api/handlers_bundles.go
+++ b/internal/api/handlers_bundles.go
@@ -18,7 +18,14 @@ import (
 
 // ── Registry proxy ────────────────────────────────────────────────────────────
 
-const registryURL = "https://raw.githubusercontent.com/kenotron-ms/amplifier-registry/main/bundles.json"
+// registryURL is the public community registry. Override with AMPLIFIER_REGISTRY_URL
+// to point at a local server during development (e.g. python3 -m http.server 8765).
+var registryURL = func() string {
+	if u := os.Getenv("AMPLIFIER_REGISTRY_URL"); u != "" {
+		return u
+	}
+	return "https://raw.githubusercontent.com/kenotron-ms/amplifier-registry/main/bundles.json"
+}()
 
 var (
 	registryCache    []json.RawMessage
@@ -258,4 +265,141 @@ func resolveAmplifier() string {
 		}
 	}
 	return "amplifier"
+}
+
+// ── Private local registry ────────────────────────────────────────────────────
+// Reads ~/.amplifier/bundle-index/index.json — maintained by the local-index CLI
+// (registry/.github/scripts/local-index.mjs).  Returns an empty array (not an
+// error) if the index has not been initialised yet.
+
+// localCapability mirrors capabilities[] entries from local-index.mjs.
+type localCapability struct {
+	Type        string  `json:"type"`
+	Name        string  `json:"name"`
+	Description *string `json:"description"`
+	Version     *string `json:"version,omitempty"`
+	SourceFile  string  `json:"sourceFile"`
+	Inferred    bool    `json:"inferred,omitempty"`
+}
+
+// localRepoEntry mirrors repos{} values from local-index.mjs index.json.
+type localRepoEntry struct {
+	RepoPath     string            `json:"repoPath"`
+	Name         string            `json:"name"`
+	Remote       string            `json:"remote"` // "org/repo" or ""
+	SHA          string            `json:"sha"`
+	ScannedAt    string            `json:"scannedAt"`
+	Capabilities []localCapability `json:"capabilities"`
+}
+
+// localIndexFile mirrors the top-level local-index.mjs index.json.
+type localIndexFile struct {
+	Version  int                       `json:"version"`
+	LastScan string                    `json:"lastScan"`
+	Repos    map[string]localRepoEntry `json:"repos"`
+}
+
+// capTypePriority controls which capability type becomes the "primary" for a repo.
+var capTypePriority = map[string]int{
+	"bundle": 0, "behavior": 1, "agent": 2,
+	"recipe": 3, "package": 4, "tool": 5,
+}
+
+// localRepoToEntry transforms a local repo into the RegistryEntry shape the UI
+// expects.  Returns nil if the repo has no capabilities.
+func localRepoToEntry(repo localRepoEntry) json.RawMessage {
+	if len(repo.Capabilities) == 0 {
+		return nil
+	}
+
+	// Pick the most significant (lowest-priority-number) capability.
+	primary := repo.Capabilities[0]
+	for _, c := range repo.Capabilities[1:] {
+		if capTypePriority[c.Type] < capTypePriority[primary.Type] {
+			primary = c
+		}
+	}
+
+	namespace, repoURL, install := "", "", ""
+	if repo.Remote != "" {
+		if idx := strings.Index(repo.Remote, "/"); idx > 0 {
+			namespace = repo.Remote[:idx]
+		}
+		repoURL = "https://github.com/" + repo.Remote
+		install = "amplifier bundle add git+https://github.com/" + repo.Remote + "@main"
+	} else {
+		repoURL = "file://" + repo.RepoPath
+		install = "amplifier bundle add git+file://" + repo.RepoPath
+	}
+
+	// Use remote slug as ID; fall back to basename of local path.
+	id := repo.Remote
+	if id == "" {
+		id = filepath.Base(repo.RepoPath)
+	}
+
+	description := ""
+	if primary.Description != nil {
+		description = *primary.Description
+	}
+
+	lastUpdated := ""
+	if len(repo.ScannedAt) >= 10 {
+		lastUpdated = repo.ScannedAt[:10]
+	}
+
+	entry := map[string]any{
+		"id":           id,
+		"name":         primary.Name,
+		"namespace":    namespace,
+		"description":  description,
+		"type":         primary.Type,
+		"category":     "dev",
+		"author":       namespace,
+		"repo":         repoURL,
+		"install":      install,
+		"rating":       nil,
+		"tags":         []string{},
+		"featured":     false,
+		"lastUpdated":  lastUpdated,
+		"private":      true,
+		"localPath":    repo.RepoPath,
+		"capabilities": repo.Capabilities,
+	}
+
+	b, err := json.Marshal(entry)
+	if err != nil {
+		return nil
+	}
+	return json.RawMessage(b)
+}
+
+// GET /api/local-registry
+func (s *Server) getLocalRegistry(w http.ResponseWriter, r *http.Request) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "cannot determine home dir")
+		return
+	}
+
+	data, err := os.ReadFile(filepath.Join(home, ".amplifier", "bundle-index", "index.json"))
+	if err != nil {
+		// Not initialised yet — return empty array, not an error.
+		writeJSON(w, http.StatusOK, []json.RawMessage{})
+		return
+	}
+
+	var idx localIndexFile
+	if err := json.Unmarshal(data, &idx); err != nil {
+		writeError(w, http.StatusInternalServerError, "malformed local bundle index")
+		return
+	}
+
+	entries := make([]json.RawMessage, 0, len(idx.Repos))
+	for _, repo := range idx.Repos {
+		if e := localRepoToEntry(repo); e != nil {
+			entries = append(entries, e)
+		}
+	}
+	writeJSON(w, http.StatusOK, entries)
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -193,6 +193,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 
 	// Registry + app bundle management
 	mux.HandleFunc("GET /api/registry", s.getRegistry)
+	mux.HandleFunc("GET /api/local-registry", s.getLocalRegistry)
 	mux.HandleFunc("GET /api/bundles", s.listBundles)
 	mux.HandleFunc("POST /api/bundles", s.addBundle)
 	mux.HandleFunc("DELETE /api/bundles/{id}", s.removeBundle)

--- a/internal/cli/index_cmd.go
+++ b/internal/cli/index_cmd.go
@@ -363,8 +363,8 @@ var indexInitCmd = &cobra.Command{
 	Long: `Creates ~/.amplifier/bundle-index/sources.json — a local, non-git-tracked
 config that tells 'loom index scan' which GitHub repos to sweep.
 
-Seeded with the MADE team feed from microsoft-amplifier/amplifier-shared
-plus your own GitHub handle (for private repo access).
+Seeded with your own GitHub handle (for private repo access).
+Edit the file to add team feeds or extra repos.
 
 Edit the file to add more handles or specific repos.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -394,12 +394,7 @@ Edit the file to add more handles or specific repos.`,
 			own = strings.TrimSpace(string(out))
 		}
 
-		src := &index.Sources{
-			TeamFeeds: []index.TeamFeed{{
-				Name: "MADE team",
-				URL:  "https://raw.githubusercontent.com/microsoft-amplifier/amplifier-shared/main/made-team.json",
-			}},
-		}
+		src := &index.Sources{}
 		if own != "" {
 			src.ExtraHandles = []string{own}
 		}
@@ -409,12 +404,13 @@ Edit the file to add more handles or specific repos.`,
 		}
 
 		fmt.Printf("\u2713 Created %s/sources.json\n\n", dir)
-		fmt.Printf("Configured:\n")
-		fmt.Printf("  Team feed:  MADE team (microsoft-amplifier/amplifier-shared)\n")
 		if own != "" {
-			fmt.Printf("  Handle:     %s (includes your private repos)\n", own)
+			fmt.Printf("Configured:\n  Handle: %s (your private repos)\n", own)
 		}
-		fmt.Printf("\nRun:\n  loom index scan\n")
+		fmt.Printf("\nAdd team feeds by editing:\n  %s/sources.json\n\n", dir)
+		fmt.Printf("Example team_feeds entry:\n")
+		fmt.Printf("  {\n    \"name\": \"My team\",\n    \"url\": \"https://raw.githubusercontent.com/org/repo/main/team.json\"\n  }\n\n")
+		fmt.Printf("Then run:\n  loom index scan\n")
 		return nil
 	},
 }

--- a/internal/cli/index_cmd.go
+++ b/internal/cli/index_cmd.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os/exec"
+	"strings"
 	"net/http"
 	"os"
 	"sort"
-	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -42,14 +43,12 @@ Token resolution order: GITHUB_TOKEN env var → gh auth token → unauthenticat
 With a token the scan runs at ~50 ms/call; without one it drops to 1.2 s/call
 to respect GitHub's anonymous rate limits.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		limit, _ := cmd.Flags().GetInt("limit")
 		force, _ := cmd.Flags().GetBool("force")
 		includeArchived, _ := cmd.Flags().GetBool("include-archived")
 		quiet, _ := cmd.Flags().GetBool("quiet")
 
 		dir := index.DefaultDir()
 		opts := index.ScanOptions{
-			Limit:           limit,
 			Force:           force,
 			IncludeArchived: includeArchived,
 			Quiet:           quiet,
@@ -356,6 +355,70 @@ var indexUnwatchCmd = &cobra.Command{
 	},
 }
 
+// ── index init ────────────────────────────────────────────────────────────────
+
+var indexInitCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Create sources.json to configure which repos to scan",
+	Long: `Creates ~/.amplifier/bundle-index/sources.json — a local, non-git-tracked
+config that tells 'loom index scan' which GitHub repos to sweep.
+
+Seeded with the MADE team feed from microsoft-amplifier/amplifier-shared
+plus your own GitHub handle (for private repo access).
+
+Edit the file to add more handles or specific repos.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir := index.DefaultDir()
+
+		existing, err := index.LoadSources(dir)
+		if err != nil {
+			return err
+		}
+		if len(existing.TeamFeeds) > 0 || len(existing.ExtraHandles) > 0 || len(existing.ExtraRepos) > 0 {
+			fmt.Printf("sources.json already exists at:\n  %s/sources.json\n\n", dir)
+			for _, f := range existing.TeamFeeds {
+				fmt.Printf("  team feed:  %s\n", f.Name)
+			}
+			if len(existing.ExtraHandles) > 0 {
+				fmt.Printf("  handles:    %v\n", existing.ExtraHandles)
+			}
+			if len(existing.ExtraRepos) > 0 {
+				fmt.Printf("  repos:      %v\n", existing.ExtraRepos)
+			}
+			fmt.Printf("\nEdit directly to add more sources:\n  %s/sources.json\n", dir)
+			return nil
+		}
+
+		own := ""
+		if out, err := exec.Command("gh", "api", "user", "--jq", ".login").Output(); err == nil {
+			own = strings.TrimSpace(string(out))
+		}
+
+		src := &index.Sources{
+			TeamFeeds: []index.TeamFeed{{
+				Name: "MADE team",
+				URL:  "https://raw.githubusercontent.com/microsoft-amplifier/amplifier-shared/main/made-team.json",
+			}},
+		}
+		if own != "" {
+			src.ExtraHandles = []string{own}
+		}
+
+		if err := index.SaveSources(dir, src); err != nil {
+			return err
+		}
+
+		fmt.Printf("\u2713 Created %s/sources.json\n\n", dir)
+		fmt.Printf("Configured:\n")
+		fmt.Printf("  Team feed:  MADE team (microsoft-amplifier/amplifier-shared)\n")
+		if own != "" {
+			fmt.Printf("  Handle:     %s (includes your private repos)\n", own)
+		}
+		fmt.Printf("\nRun:\n  loom index scan\n")
+		return nil
+	},
+}
+
 // ── init ──────────────────────────────────────────────────────────────────────
 
 func init() {
@@ -378,6 +441,7 @@ func init() {
 	indexWatchCmd.Flags().String("every", "2h", "Scan interval (e.g. 30m, 2h)")
 
 	indexCmd.AddCommand(
+		indexInitCmd,
 		indexScanCmd,
 		indexListCmd,
 		indexStatusCmd,

--- a/internal/cli/index_cmd.go
+++ b/internal/cli/index_cmd.go
@@ -1,0 +1,387 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ms/amplifier-app-loom/internal/config"
+	"github.com/ms/amplifier-app-loom/internal/index"
+	"github.com/ms/amplifier-app-loom/internal/types"
+)
+
+// indexCmd is the parent command for GitHub bundle index operations.
+var indexCmd = &cobra.Command{
+	Use:   "index",
+	Short: "Manage the local GitHub bundle index",
+	Long: `Scan GitHub for Amplifier bundles and browse the results locally.
+
+The index stores metadata about every repo accessible to your GitHub token
+that looks like an Amplifier bundle. Use 'index scan' to populate it and
+'index list' to browse what was found.`,
+}
+
+// ── index scan ───────────────────────────────────────────────────────────────
+
+var indexScanCmd = &cobra.Command{
+	Use:   "scan",
+	Short: "Scan GitHub for amplifier bundles",
+	Long: `Scan all GitHub repositories accessible to your token and build a local
+index of Amplifier bundles.
+
+Token resolution order: GITHUB_TOKEN env var → gh auth token → unauthenticated.
+
+With a token the scan runs at ~50 ms/call; without one it drops to 1.2 s/call
+to respect GitHub's anonymous rate limits.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		limit, _ := cmd.Flags().GetInt("limit")
+		force, _ := cmd.Flags().GetBool("force")
+		includeArchived, _ := cmd.Flags().GetBool("include-archived")
+		quiet, _ := cmd.Flags().GetBool("quiet")
+
+		dir := index.DefaultDir()
+		opts := index.ScanOptions{
+			Limit:           limit,
+			Force:           force,
+			IncludeArchived: includeArchived,
+			Quiet:           quiet,
+		}
+
+		result, err := index.Scan(cmd.Context(), dir, opts)
+		if err != nil {
+			return err
+		}
+
+		if !quiet {
+			fmt.Printf("\n✓ Scan complete: %d added, %d updated, %d unchanged (%d API calls remaining)\n",
+				len(result.Added), len(result.Updated), result.Unchanged, result.APIRemaining)
+			if len(result.Removed) > 0 {
+				fmt.Printf("  Removed %d repo(s) no longer accessible.\n", len(result.Removed))
+			}
+			fmt.Printf("  Run 'loom index list' to browse results.\n")
+		}
+		return nil
+	},
+}
+
+// ── index list ───────────────────────────────────────────────────────────────
+
+var indexListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List indexed amplifier bundles",
+	Long: `Browse the local bundle index, grouped by GitHub organisation.
+
+Shows the primary capability type, a short description, and badges for
+private repos (🔒) and star count (★N).`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		jsonOut, _ := cmd.Flags().GetBool("json")
+		privateOnly, _ := cmd.Flags().GetBool("private-only")
+
+		dir := index.DefaultDir()
+		idx, err := index.LoadIndex(dir)
+		if err != nil {
+			return err
+		}
+
+		if jsonOut {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			return enc.Encode(idx)
+		}
+
+		if len(idx.Repos) == 0 {
+			fmt.Println("No repos indexed. Run 'loom index scan' first.")
+			return nil
+		}
+
+		// Group by org (the part before "/" in Remote).
+		orgMap := make(map[string][]index.Entry)
+		for _, e := range idx.Repos {
+			if privateOnly && !e.Private {
+				continue
+			}
+			org := e.Remote
+			if i := strings.Index(e.Remote, "/"); i >= 0 {
+				org = e.Remote[:i]
+			}
+			orgMap[org] = append(orgMap[org], e)
+		}
+
+		if len(orgMap) == 0 {
+			fmt.Println("No repos match the current filters.")
+			return nil
+		}
+
+		// Sort orgs then entries within each org.
+		orgs := make([]string, 0, len(orgMap))
+		for org := range orgMap {
+			orgs = append(orgs, org)
+		}
+		sort.Strings(orgs)
+
+		for _, org := range orgs {
+			entries := orgMap[org]
+			sort.Slice(entries, func(i, j int) bool {
+				return entries[i].Name < entries[j].Name
+			})
+
+			fmt.Printf("%s\n", org)
+
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			for _, e := range entries {
+				// Primary capability type.
+				capType := ""
+				if len(e.Capabilities) > 0 {
+					capType = "[" + e.Capabilities[0].Type + "]"
+				}
+
+				// Description truncated to 55 runes.
+				desc := e.Description
+				runes := []rune(desc)
+				if len(runes) > 55 {
+					desc = string(runes[:55]) + "..."
+				}
+
+				// Badges: 🔒 for private, ★N for stars.
+				var badges []string
+				if e.Private {
+					badges = append(badges, "🔒")
+				}
+				if e.Stars > 0 {
+					badges = append(badges, fmt.Sprintf("★%d", e.Stars))
+				}
+				badge := strings.Join(badges, " ")
+
+				fmt.Fprintf(w, "  %s\t%s\t%s\t%s\n", e.Name, capType, desc, badge)
+			}
+			w.Flush() //nolint:errcheck
+		}
+		return nil
+	},
+}
+
+// ── index status ─────────────────────────────────────────────────────────────
+
+var indexStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show index store statistics",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir := index.DefaultDir()
+
+		idx, err := index.LoadIndex(dir)
+		if err != nil {
+			return err
+		}
+		st, err := index.LoadState(dir)
+		if err != nil {
+			return err
+		}
+
+		indexed := len(idx.Repos)
+		scanned := len(st.Repos)
+		skipped := scanned - indexed
+		if skipped < 0 {
+			skipped = 0
+		}
+
+		// Tally capabilities by type.
+		typeCounts := make(map[string]int)
+		totalCaps := 0
+		for _, e := range idx.Repos {
+			for _, c := range e.Capabilities {
+				typeCounts[c.Type]++
+				totalCaps++
+			}
+		}
+
+		// Build a sorted, count-descending summary string.
+		typeNames := make([]string, 0, len(typeCounts))
+		for t := range typeCounts {
+			typeNames = append(typeNames, t)
+		}
+		sort.Slice(typeNames, func(i, j int) bool {
+			if typeCounts[typeNames[i]] != typeCounts[typeNames[j]] {
+				return typeCounts[typeNames[i]] > typeCounts[typeNames[j]]
+			}
+			return typeNames[i] < typeNames[j]
+		})
+		capsDetail := ""
+		if len(typeNames) > 0 {
+			parts := make([]string, 0, len(typeNames))
+			for _, t := range typeNames {
+				parts = append(parts, fmt.Sprintf("%d %ss", typeCounts[t], t))
+			}
+			capsDetail = " (" + strings.Join(parts, ", ") + ")"
+		}
+
+		// Substitute ~ for home directory in the display path.
+		homeDir, _ := os.UserHomeDir()
+		displayDir := strings.Replace(dir, homeDir, "~", 1)
+
+		// Format last scan timestamp.
+		lastScan := "never"
+		if idx.LastScan != "" {
+			if t, e := time.Parse(time.RFC3339, idx.LastScan); e == nil {
+				lastScan = t.Local().Format("Jan 2, 2006 3:04 PM")
+			}
+		}
+
+		fmt.Printf("GitHub Bundle Index\n")
+		fmt.Printf("  Store:     %s\n", displayDir)
+		fmt.Printf("  Repos:     %d indexed (%d scanned, %d skipped)\n", indexed, scanned, skipped)
+		fmt.Printf("  Caps:      %d%s\n", totalCaps, capsDetail)
+		fmt.Printf("  Last scan: %s\n", lastScan)
+
+		if st.RateLimit != nil && st.RateLimit.ResetAt > 0 {
+			resetTime := time.Unix(st.RateLimit.ResetAt, 0).Local().Format("3:04 PM")
+			fmt.Printf("  Rate:      %d remaining (resets %s)\n", st.RateLimit.Remaining, resetTime)
+		} else {
+			fmt.Printf("  Rate:      unknown\n")
+		}
+
+		return nil
+	},
+}
+
+// ── index watch ──────────────────────────────────────────────────────────────
+
+var indexWatchCmd = &cobra.Command{
+	Use:   "watch",
+	Short: "Schedule periodic background scans via the loom daemon",
+	Long: `Creates a loom loop job that runs 'loom index scan --quiet' on the given
+interval. Requires the loom daemon to be running.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		port, _ := cmd.Flags().GetInt("port")
+		every, _ := cmd.Flags().GetString("every")
+
+		execPath, err := os.Executable()
+		if err != nil {
+			execPath = "loom"
+		}
+
+		job := types.Job{
+			Name: "amplifier-bundle-index",
+			Trigger: types.Trigger{
+				Type:     types.TriggerLoop,
+				Schedule: every,
+			},
+			Executor: types.ExecutorShell,
+			Shell: &types.ShellConfig{
+				Command: execPath + " index scan --quiet",
+			},
+			Enabled: true,
+		}
+
+		body, err := json.Marshal(job)
+		if err != nil {
+			return fmt.Errorf("failed to encode job: %w", err)
+		}
+
+		resp, err := http.Post(
+			fmt.Sprintf("http://localhost:%d/api/jobs", port),
+			"application/json",
+			bytes.NewReader(body),
+		)
+		if err != nil {
+			return fmt.Errorf("daemon not reachable: %w", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode >= 400 {
+			var e map[string]string
+			json.NewDecoder(resp.Body).Decode(&e) //nolint:errcheck
+			return fmt.Errorf("error: %s", e["error"])
+		}
+
+		fmt.Printf("✓ Scheduled background scan every %s\n", every)
+		fmt.Printf("  Run 'loom index unwatch' to remove the schedule.\n")
+		return nil
+	},
+}
+
+// ── index unwatch ─────────────────────────────────────────────────────────────
+
+var indexUnwatchCmd = &cobra.Command{
+	Use:   "unwatch",
+	Short: "Remove the periodic scan schedule",
+	Long:  `Finds the loom job named "amplifier-bundle-index" and deletes it.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		port, _ := cmd.Flags().GetInt("port")
+
+		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/api/jobs", port))
+		if err != nil {
+			return fmt.Errorf("daemon not reachable: %w", err)
+		}
+		defer resp.Body.Close()
+
+		var jobs []*types.Job
+		if err := json.NewDecoder(resp.Body).Decode(&jobs); err != nil {
+			return err
+		}
+
+		var jobID string
+		for _, j := range jobs {
+			if j.Name == "amplifier-bundle-index" {
+				jobID = j.ID
+				break
+			}
+		}
+		if jobID == "" {
+			fmt.Println("No active watch job found (nothing to remove).")
+			return nil
+		}
+
+		req, _ := http.NewRequest(http.MethodDelete,
+			fmt.Sprintf("http://localhost:%d/api/jobs/%s", port, jobID), nil)
+		delResp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("daemon not reachable: %w", err)
+		}
+		defer delResp.Body.Close()
+
+		if delResp.StatusCode >= 400 {
+			return fmt.Errorf("error removing watch job (status %d)", delResp.StatusCode)
+		}
+
+		fmt.Println("✓ Background scan schedule removed.")
+		return nil
+	},
+}
+
+// ── init ──────────────────────────────────────────────────────────────────────
+
+func init() {
+	// Port flag for daemon-backed commands.
+	for _, cmd := range []*cobra.Command{indexWatchCmd, indexUnwatchCmd} {
+		cmd.Flags().Int("port", config.DefaultPort, "Daemon port")
+	}
+
+	// scan flags
+	indexScanCmd.Flags().Int("limit", 0, "Max repos to scan (0 = all)")
+	indexScanCmd.Flags().Bool("force", false, "Re-scan even if pushed_at is unchanged")
+	indexScanCmd.Flags().Bool("include-archived", false, "Include archived repos")
+	indexScanCmd.Flags().BoolP("quiet", "q", false, "Suppress progress output")
+
+	// list flags
+	indexListCmd.Flags().Bool("json", false, "Output the full index as JSON")
+	indexListCmd.Flags().Bool("private-only", false, "Show only private repos")
+
+	// watch flags
+	indexWatchCmd.Flags().String("every", "2h", "Scan interval (e.g. 30m, 2h)")
+
+	indexCmd.AddCommand(
+		indexScanCmd,
+		indexListCmd,
+		indexStatusCmd,
+		indexWatchCmd,
+		indexUnwatchCmd,
+	)
+}

--- a/internal/cli/registry_cmd.go
+++ b/internal/cli/registry_cmd.go
@@ -14,7 +14,8 @@ import (
 
 // registryCmd is the parent command for browsing the bundle registry.
 var registryCmd = &cobra.Command{
-	Use:   "registry",
+	Use:     "registry",
+	Aliases: []string{"reg"},
 	Short: "Browse the Amplifier bundle registry",
 	Long: `Search and browse the Amplifier bundle registry — both the public community
 registry and your private local index (from 'loom index scan').

--- a/internal/cli/registry_cmd.go
+++ b/internal/cli/registry_cmd.go
@@ -1,0 +1,347 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/ms/amplifier-app-loom/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// registryCmd is the parent command for browsing the bundle registry.
+var registryCmd = &cobra.Command{
+	Use:   "registry",
+	Short: "Browse the Amplifier bundle registry",
+	Long: `Search and browse the Amplifier bundle registry — both the public community
+registry and your private local index (from 'loom index scan').
+
+Use 'registry list' to browse, 'registry search' to filter by keyword,
+and 'registry show' to inspect a specific bundle. To install a bundle
+found in the registry, use 'loom bundle add <install-spec>'.`,
+}
+
+// registryEntry is the minimal shape we need from the registry JSON.
+type registryEntry struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Namespace   string   `json:"namespace"`
+	Description string   `json:"description"`
+	Type        string   `json:"type"`
+	Category    string   `json:"category"`
+	Author      string   `json:"author"`
+	Repo        string   `json:"repo"`
+	Install     string   `json:"install"`
+	Rating      *float64 `json:"rating"`
+	Stars       *int     `json:"stars"`
+	Tags        []string `json:"tags"`
+	Featured    bool     `json:"featured"`
+	LastUpdated string   `json:"lastUpdated"`
+	LLMVerdict  string   `json:"llmVerdict"`
+	Private     bool     `json:"private"`
+	LocalPath   string   `json:"localPath"`
+}
+
+// ── registry list ─────────────────────────────────────────────────────────────
+
+var registryListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List bundles in the registry",
+	Example: `  loom registry list
+  loom registry list --search superpowers
+  loom registry list --type agent --category dev
+  loom registry list --private`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		port, _     := cmd.Flags().GetInt("port")
+		search, _   := cmd.Flags().GetString("search")
+		typeF, _    := cmd.Flags().GetString("type")
+		catF, _     := cmd.Flags().GetString("category")
+		privateOnly, _ := cmd.Flags().GetBool("private")
+		asJSON, _   := cmd.Flags().GetBool("json")
+
+		entries, err := fetchAllRegistry(port)
+		if err != nil {
+			return err
+		}
+
+		// Filter
+		q := strings.ToLower(search)
+		filtered := entries[:0]
+		for _, e := range entries {
+			if privateOnly && !e.Private {
+				continue
+			}
+			if typeF != "" && !strings.EqualFold(e.Type, typeF) {
+				continue
+			}
+			if catF != "" && !strings.EqualFold(e.Category, catF) {
+				continue
+			}
+			if q != "" {
+				haystack := strings.ToLower(e.Name + " " + e.Description + " " + strings.Join(e.Tags, " "))
+				if !strings.Contains(haystack, q) {
+					continue
+				}
+			}
+			filtered = append(filtered, e)
+		}
+
+		if asJSON {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			return enc.Encode(filtered)
+		}
+
+		if len(filtered) == 0 {
+			fmt.Println("No registry entries match your filters.")
+			return nil
+		}
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "NAME\tTYPE\tAUTHOR\tDESCRIPTION")
+		for _, e := range filtered {
+			desc := e.Description
+			if len(desc) > 55 {
+				desc = desc[:52] + "..."
+			}
+			lock := ""
+			if e.Private {
+				lock = " 🔒"
+			}
+			stars := ""
+			if e.Stars != nil && *e.Stars > 0 {
+				stars = fmt.Sprintf(" ★%d", *e.Stars)
+			}
+			fmt.Fprintf(w, "%s%s%s\t[%s]\t%s\t%s\n",
+				e.Name, lock, stars, e.Type, e.Namespace, desc)
+		}
+		_ = w.Flush()
+		fmt.Printf("\n%d bundle(s) shown", len(filtered))
+		pub  := 0
+		priv := 0
+		for _, e := range filtered {
+			if e.Private { priv++ } else { pub++ }
+		}
+		if priv > 0 {
+			fmt.Printf(" (%d public, %d private 🔒)", pub, priv)
+		}
+		fmt.Println()
+		return nil
+	},
+}
+
+// ── registry search ───────────────────────────────────────────────────────────
+
+var registrySearchCmd = &cobra.Command{
+	Use:     "search <query>",
+	Aliases: []string{"find"},
+	Short:   "Search the registry by name, description, or tags",
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		port, _ := cmd.Flags().GetInt("port")
+		q := strings.ToLower(args[0])
+
+		entries, err := fetchAllRegistry(port)
+		if err != nil {
+			return err
+		}
+
+		filtered := entries[:0]
+		for _, e := range entries {
+			haystack := strings.ToLower(e.Name + " " + e.Description + " " + strings.Join(e.Tags, " "))
+			if strings.Contains(haystack, q) {
+				filtered = append(filtered, e)
+			}
+		}
+
+		if len(filtered) == 0 {
+			fmt.Printf("No bundles matching %q\n", args[0])
+			return nil
+		}
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "NAME\tTYPE\tAUTHOR\tDESCRIPTION")
+		for _, e := range filtered {
+			desc := e.Description
+			if len(desc) > 55 {
+				desc = desc[:52] + "..."
+			}
+			lock := ""
+			if e.Private {
+				lock = " 🔒"
+			}
+			fmt.Fprintf(w, "%s%s\t[%s]\t%s\t%s\n", e.Name, lock, e.Type, e.Namespace, desc)
+		}
+		_ = w.Flush()
+		fmt.Printf("\n%d result(s) for %q\n", len(filtered), args[0])
+		return nil
+	},
+}
+
+// ── registry show ─────────────────────────────────────────────────────────────
+
+var registryShowCmd = &cobra.Command{
+	Use:     "show <id>",
+	Aliases: []string{"info", "get"},
+	Short:   "Show details for a specific bundle",
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		port, _ := cmd.Flags().GetInt("port")
+		id       := strings.ToLower(args[0])
+
+		entries, err := fetchAllRegistry(port)
+		if err != nil {
+			return err
+		}
+
+		// Find by id, name, or partial match
+		var match *registryEntry
+		for i := range entries {
+			e := &entries[i]
+			if strings.EqualFold(e.ID, id) || strings.EqualFold(e.Name, id) {
+				match = e
+				break
+			}
+		}
+		if match == nil {
+			// Try prefix match
+			for i := range entries {
+				e := &entries[i]
+				if strings.HasPrefix(strings.ToLower(e.Name), id) ||
+					strings.HasPrefix(strings.ToLower(e.ID), id) {
+					match = e
+					break
+				}
+			}
+		}
+		if match == nil {
+			return fmt.Errorf("no bundle found matching %q\nTry: loom registry search %s", id, id)
+		}
+
+		// Pretty-print
+		lock := ""
+		if match.Private {
+			lock = " 🔒 private"
+		}
+		fmt.Printf("\n  %s  [%s]%s\n", bold(match.Name), match.Type, lock)
+		if match.Namespace != "" {
+			fmt.Printf("  %s\n", dim("by "+match.Namespace))
+		}
+		if match.Description != "" {
+			fmt.Printf("\n  %s\n", match.Description)
+		}
+		if match.LLMVerdict != "" {
+			fmt.Printf("  %q\n", match.LLMVerdict)
+		}
+		fmt.Println()
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		if match.Repo != "" {
+			fmt.Fprintf(w, "  Repo:\t%s\n", match.Repo)
+		}
+		if match.Category != "" {
+			fmt.Fprintf(w, "  Category:\t%s\n", match.Category)
+		}
+		if len(match.Tags) > 0 {
+			fmt.Fprintf(w, "  Tags:\t%s\n", strings.Join(match.Tags, ", "))
+		}
+		if match.Rating != nil {
+			fmt.Fprintf(w, "  Rating:\t%.1f / 5.0\n", *match.Rating)
+		}
+		if match.Stars != nil {
+			fmt.Fprintf(w, "  Stars:\t%d\n", *match.Stars)
+		}
+		if match.LastUpdated != "" {
+			fmt.Fprintf(w, "  Updated:\t%s\n", match.LastUpdated)
+		}
+		if match.LocalPath != "" {
+			fmt.Fprintf(w, "  Local path:\t%s\n", match.LocalPath)
+		}
+		_ = w.Flush()
+
+		fmt.Printf("\n  Install:\n    %s\n\n", match.Install)
+		return nil
+	},
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// fetchAllRegistry fetches both /api/registry (public) and /api/local-registry
+// (private), deduplicating by ID (local wins on conflict).
+func fetchAllRegistry(port int) ([]registryEntry, error) {
+	pub,  err1 := fetchRegistryEndpoint(port, "registry")
+	priv, err2 := fetchRegistryEndpoint(port, "local-registry")
+
+	if err1 != nil && err2 != nil {
+		return nil, fmt.Errorf("daemon not reachable at localhost:%d — is loom running?\n  Start it with: loom start", port)
+	}
+
+	// Merge: public first, then private (private overrides on same ID)
+	seen    := map[string]bool{}
+	merged  := make([]registryEntry, 0, len(pub)+len(priv))
+
+	// Private first so they appear at top
+	for _, e := range priv {
+		if !seen[e.ID] {
+			seen[e.ID] = true
+			merged = append(merged, e)
+		}
+	}
+	for _, e := range pub {
+		if !seen[e.ID] {
+			seen[e.ID] = true
+			merged = append(merged, e)
+		}
+	}
+	return merged, nil
+}
+
+func fetchRegistryEndpoint(port int, endpoint string) ([]registryEntry, error) {
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/api/%s", port, endpoint))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d from /api/%s", resp.StatusCode, endpoint)
+	}
+	var entries []registryEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+// bold/dim helpers (ANSI, no-op when not a TTY)
+func bold(s string) string {
+	if f, ok := os.Stdout.Stat(); ok == nil && f.Mode()&os.ModeCharDevice != 0 {
+		return "\x1b[1m" + s + "\x1b[0m"
+	}
+	return s
+}
+func dim(s string) string {
+	if f, ok := os.Stdout.Stat(); ok == nil && f.Mode()&os.ModeCharDevice != 0 {
+		return "\x1b[2m" + s + "\x1b[0m"
+	}
+	return s
+}
+
+func init() {
+	for _, cmd := range []*cobra.Command{
+		registryListCmd, registrySearchCmd, registryShowCmd,
+	} {
+		cmd.Flags().Int("port", config.DefaultPort, "Daemon port")
+	}
+
+	registryListCmd.Flags().String("search", "", "Filter by name/description/tags")
+	registryListCmd.Flags().String("type", "", "Filter by type (bundle, agent, tool, behavior, recipe)")
+	registryListCmd.Flags().String("category", "", "Filter by category (dev, infra, knowledge, ...)")
+	registryListCmd.Flags().Bool("private", false, "Show only private/local bundles")
+	registryListCmd.Flags().Bool("json", false, "Output as JSON")
+
+	registryCmd.AddCommand(registryListCmd, registrySearchCmd, registryShowCmd)
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -56,5 +56,6 @@ func init() {
 		mirrorCmd,     // mirror subcommands: entities, get, changes, connectors
 		connectorCmd,  // connector subcommands: add, list, remove
 		bundleCmd,     // bundle subcommands: install, add, list, remove
+		indexCmd,      // index subcommands: scan, list, status, watch, unwatch
 	)
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -57,5 +57,6 @@ func init() {
 		connectorCmd,  // connector subcommands: add, list, remove
 		bundleCmd,     // bundle subcommands: install, add, list, remove
 		indexCmd,      // index subcommands: scan, list, status, watch, unwatch
+		registryCmd,   // registry subcommands: list, search, show
 	)
 }

--- a/internal/index/scanner.go
+++ b/internal/index/scanner.go
@@ -87,6 +87,14 @@ func extractHandles(members []madeTeamMember) []string {
 	return out
 }
 
+// stripTrailingCommas removes trailing commas before ] or } to handle
+// relaxed JSON files (e.g. those edited by humans without strict JSON linting).
+func stripTrailingCommas(data []byte) []byte {
+	// Replace ,<whitespace>} and ,<whitespace>] patterns
+	result := trailingCommaRe.ReplaceAll(data, []byte(""))
+	return result
+}
+
 // resolveHandles fetches all team feeds and merges with ExtraHandles.
 // Returns deduped list of GitHub handles.
 func resolveHandles(ctx context.Context, token string, src Sources) ([]string, error) {
@@ -106,8 +114,10 @@ func resolveHandles(ctx context.Context, token string, src Sources) ([]string, e
 		if err != nil {
 			return nil, fmt.Errorf("fetching team feed %q: %w", feed.Name, err)
 		}
+		body = stripTrailingCommas(body)
 		var team madeTeamJSON
-		if err := json.Unmarshal(body, &team); err != nil {
+		decoder := json.NewDecoder(strings.NewReader(string(body)))
+		if err := decoder.Decode(&team); err != nil {
 			return nil, fmt.Errorf("parsing team feed %q: %w", feed.Name, err)
 		}
 		for _, h := range extractHandles(team.TeamMembers) {
@@ -125,6 +135,7 @@ func resolveHandles(ctx context.Context, token string, src Sources) ([]string, e
 // ── compiled regexps ──────────────────────────────────────────────────────────
 
 var (
+	trailingCommaRe = regexp.MustCompile(`,\s*([}\]])`)
 	reBehaviors  = regexp.MustCompile(`^behaviors/([^/]+)\.yaml$`)
 	reAgents     = regexp.MustCompile(`^agents/([^/]+)\.md$`)
 	reRecipes    = regexp.MustCompile(`^recipes/([^/]+)\.yaml$`)

--- a/internal/index/scanner.go
+++ b/internal/index/scanner.go
@@ -241,11 +241,20 @@ func ghGet(ctx context.Context, token, path string, delay *time.Duration, remain
 	return body, resp.StatusCode, nil
 }
 
-// rawFile fetches a file via raw.githubusercontent.com (no API quota).
-func rawFile(owner, repo, branch, path string) (string, error) {
+// rawFile fetches a file via raw.githubusercontent.com.
+// Pass token for private repo access (sent as Authorization header).
+// No API quota cost for public repos; private repos require authentication.
+func rawFile(token, owner, repo, branch, path string) (string, error) {
 	url := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s",
 		owner, repo, branch, path)
-	resp, err := http.Get(url) //nolint:noctx
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -440,7 +449,7 @@ func parsePyprojectTOML(content string) (name, desc string) {
 	return
 }
 
-func ExtractCapabilities(owner, repo, branch string, paths []string, readmeText string) ([]Capability, error) {
+func ExtractCapabilities(token, owner, repo, branch string, paths []string, readmeText string) ([]Capability, error) {
 	pathSet := make(map[string]bool, len(paths))
 	for _, p := range paths {
 		pathSet[p] = true
@@ -453,7 +462,7 @@ func ExtractCapabilities(owner, repo, branch string, paths []string, readmeText 
 		if !pathSet[fname] {
 			continue
 		}
-		content, err := rawFile(owner, repo, branch, fname)
+		content, err := rawFile(token, owner, repo, branch, fname)
 		if err != nil || content == "" {
 			continue
 		}
@@ -487,7 +496,7 @@ func ExtractCapabilities(owner, repo, branch string, paths []string, readmeText 
 		if m == nil {
 			continue
 		}
-		content, err := rawFile(owner, repo, branch, p)
+		content, err := rawFile(token, owner, repo, branch, p)
 		if err != nil || content == "" {
 			continue
 		}
@@ -511,7 +520,7 @@ func ExtractCapabilities(owner, repo, branch string, paths []string, readmeText 
 		if m == nil {
 			continue
 		}
-		content, err := rawFile(owner, repo, branch, p)
+		content, err := rawFile(token, owner, repo, branch, p)
 		if err != nil || content == "" {
 			continue
 		}
@@ -538,7 +547,7 @@ func ExtractCapabilities(owner, repo, branch string, paths []string, readmeText 
 		} else {
 			continue
 		}
-		content, err := rawFile(owner, repo, branch, p)
+		content, err := rawFile(token, owner, repo, branch, p)
 		if err != nil || content == "" {
 			continue
 		}
@@ -563,7 +572,7 @@ func ExtractCapabilities(owner, repo, branch string, paths []string, readmeText 
 
 	// Pass 5: pyproject.toml
 	if pathSet["pyproject.toml"] {
-		content, err := rawFile(owner, repo, branch, "pyproject.toml")
+		content, err := rawFile(token, owner, repo, branch, "pyproject.toml")
 		if err == nil && content != "" {
 			if pName, pDesc := parsePyprojectTOML(content); pName != "" {
 				caps = append(caps, Capability{
@@ -797,8 +806,8 @@ func Scan(ctx context.Context, dir string, opts ScanOptions) (*ScanResult, error
 		// Extract capabilities
 		parts := strings.SplitN(key, "/", 2)
 		ownerName, repoName := parts[0], parts[1]
-		readmeText, _ := rawFile(ownerName, repoName, defaultBranch, "README.md")
-		caps, _ := ExtractCapabilities(ownerName, repoName, defaultBranch, paths, readmeText)
+		readmeText, _ := rawFile(token, ownerName, repoName, defaultBranch, "README.md")
+		caps, _ := ExtractCapabilities(token, ownerName, repoName, defaultBranch, paths, readmeText)
 
 		name, _ := repo["name"].(string)
 		desc, _ := repo["description"].(string)

--- a/internal/index/scanner.go
+++ b/internal/index/scanner.go
@@ -16,39 +16,125 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// ScanOptions controls how Scan operates.
+// ── ScanOptions / ScanResult ──────────────────────────────────────────────────
+
 type ScanOptions struct {
-	Limit           int  // 0 = unlimited
-	Force           bool // re-scan even if pushed_at unchanged
+	Force           bool
 	IncludeArchived bool
 	Quiet           bool
 }
 
-// ScanResult summarises what changed during a Scan run.
 type ScanResult struct {
 	Added        []Entry
 	Updated      []Entry
-	Removed      []string // remote keys ("org/repo") removed from the index
+	Removed      []string
 	Unchanged    int
 	Skipped      int
 	APIRemaining int
 }
 
-// ── package-level compiled regexps ──────────────────────────────────────────
+// ── Sources config ────────────────────────────────────────────────────────────
+//
+// ~/.amplifier/bundle-index/sources.json — NOT in any repo.
+// Controls which repos get scanned.
+
+type Sources struct {
+	// Remote team-JSON feeds (e.g. made-team.json from amplifier-shared).
+	// Handles are extracted and each handle's repos are scanned.
+	TeamFeeds []TeamFeed `json:"team_feeds"`
+
+	// Additional individual GitHub handles to scan.
+	ExtraHandles []string `json:"extra_handles"`
+
+	// Additional specific repos to always scan (org/repo format).
+	ExtraRepos []string `json:"extra_repos"`
+}
+
+type TeamFeed struct {
+	Name string `json:"name"`
+	URL  string `json:"url"` // raw URL to a made-team.json file
+}
+
+// madeTeamJSON is the schema of made-team.json.
+type madeTeamJSON struct {
+	TeamMembers []madeTeamMember `json:"team_members"`
+}
+
+type madeTeamMember struct {
+	Name     string           `json:"name"`
+	GHHandle string           `json:"gh_handle"`
+	Directs  []madeTeamMember `json:"directs"`
+}
+
+// extractHandles flattens all gh_handle values from the tree.
+func extractHandles(members []madeTeamMember) []string {
+	seen := map[string]bool{}
+	var out []string
+	var walk func(m madeTeamMember)
+	walk = func(m madeTeamMember) {
+		if m.GHHandle != "" && !seen[m.GHHandle] {
+			seen[m.GHHandle] = true
+			out = append(out, m.GHHandle)
+		}
+		for _, d := range m.Directs {
+			walk(d)
+		}
+	}
+	for _, m := range members {
+		walk(m)
+	}
+	return out
+}
+
+// resolveHandles fetches all team feeds and merges with ExtraHandles.
+// Returns deduped list of GitHub handles.
+func resolveHandles(ctx context.Context, src Sources) ([]string, error) {
+	seen := map[string]bool{}
+	var handles []string
+
+	add := func(h string) {
+		h = strings.TrimSpace(h)
+		if h != "" && !seen[h] {
+			seen[h] = true
+			handles = append(handles, h)
+		}
+	}
+
+	for _, feed := range src.TeamFeeds {
+		body, err := httpGet(ctx, feed.URL, "")
+		if err != nil {
+			return nil, fmt.Errorf("fetching team feed %q: %w", feed.Name, err)
+		}
+		var team madeTeamJSON
+		if err := json.Unmarshal(body, &team); err != nil {
+			return nil, fmt.Errorf("parsing team feed %q: %w", feed.Name, err)
+		}
+		for _, h := range extractHandles(team.TeamMembers) {
+			add(h)
+		}
+	}
+
+	for _, h := range src.ExtraHandles {
+		add(h)
+	}
+
+	return handles, nil
+}
+
+// ── compiled regexps ──────────────────────────────────────────────────────────
 
 var (
-	reBehaviors = regexp.MustCompile(`^behaviors/([^/]+)\.yaml$`)
-	reAgents    = regexp.MustCompile(`^agents/([^/]+)\.md$`)
-	reRecipes   = regexp.MustCompile(`^recipes/([^/]+)\.yaml$`)
+	reBehaviors  = regexp.MustCompile(`^behaviors/([^/]+)\.yaml$`)
+	reAgents     = regexp.MustCompile(`^agents/([^/]+)\.md$`)
+	reRecipes    = regexp.MustCompile(`^recipes/([^/]+)\.yaml$`)
 	reAmpRecipes = regexp.MustCompile(`^\.amplifier/recipes/([^/]+)\.yaml$`)
 	rePySection  = regexp.MustCompile(`^\[([^\]]+)\]`)
 	rePyName     = regexp.MustCompile(`^name\s*=\s*"([^"]*)"`)
 	rePyDesc     = regexp.MustCompile(`^description\s*=\s*"([^"]*)"`)
 )
 
-// ── token resolution ─────────────────────────────────────────────────────────
+// ── token resolution ──────────────────────────────────────────────────────────
 
-// resolveToken returns: GITHUB_TOKEN env var → gh auth token → empty string.
 func resolveToken() string {
 	if tok := os.Getenv("GITHUB_TOKEN"); tok != "" {
 		return tok
@@ -62,11 +148,30 @@ func resolveToken() string {
 	return ""
 }
 
-// ── GitHub API helper ────────────────────────────────────────────────────────
+// ── HTTP helpers ──────────────────────────────────────────────────────────────
 
-// ghGet makes a GET request to https://api.github.com/{path}.
-// It sleeps *delay before the request, then updates *remaining/*resetAt from
-// X-RateLimit-* response headers and adjusts *delay for the next call.
+// httpGet is a plain GET used for non-API URLs (team feeds, raw files).
+func httpGet(ctx context.Context, url, token string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d from %s", resp.StatusCode, url)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+// ghGet makes a rate-aware GET to the GitHub API.
+// Updates *delay/*remaining/*resetAt from response headers.
 // Returns (nil, 304, nil) for 304 Not Modified.
 func ghGet(ctx context.Context, token, path string, delay *time.Duration, remaining *int, resetAt *int64) ([]byte, int, error) {
 	if *delay > 0 {
@@ -82,7 +187,8 @@ func ghGet(ctx context.Context, token, path string, delay *time.Duration, remain
 	if err != nil {
 		return nil, 0, err
 	}
-	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
@@ -93,7 +199,6 @@ func ghGet(ctx context.Context, token, path string, delay *time.Duration, remain
 	}
 	defer resp.Body.Close()
 
-	// Track rate limits.
 	if rem := resp.Header.Get("X-RateLimit-Remaining"); rem != "" {
 		if v, e := strconv.Atoi(rem); e == nil {
 			*remaining = v
@@ -105,7 +210,7 @@ func ghGet(ctx context.Context, token, path string, delay *time.Duration, remain
 		}
 	}
 
-	// Adjust delay for next call.
+	// Adjust delay for next call
 	if token != "" {
 		switch {
 		case *remaining < 20:
@@ -135,10 +240,7 @@ func ghGet(ctx context.Context, token, path string, delay *time.Duration, remain
 	return body, resp.StatusCode, nil
 }
 
-// ── raw file fetch (no quota) ─────────────────────────────────────────────────
-
-// rawFile fetches a raw file from raw.githubusercontent.com.
-// Returns ("", nil) if the file is not found.
+// rawFile fetches a file via raw.githubusercontent.com (no API quota).
 func rawFile(owner, repo, branch, path string) (string, error) {
 	url := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s",
 		owner, repo, branch, path)
@@ -154,15 +256,10 @@ func rawFile(owner, repo, branch, path string) (string, error) {
 		return "", nil
 	}
 	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-	return string(body), nil
+	return string(body), err
 }
 
-// ── GitHub API pagination ─────────────────────────────────────────────────────
-
-// parseNextLink extracts the "next" URL from a GitHub Link header.
+// parseNextLink extracts the "next" URL from a GitHub Link response header.
 func parseNextLink(header string) string {
 	for _, part := range strings.Split(header, ",") {
 		part = strings.TrimSpace(part)
@@ -171,94 +268,40 @@ func parseNextLink(header string) string {
 			continue
 		}
 		if strings.TrimSpace(segs[1]) == `rel="next"` {
-			u := strings.TrimSpace(segs[0])
-			return strings.Trim(u, "<>")
+			return strings.Trim(strings.TrimSpace(segs[0]), "<>")
 		}
 	}
 	return ""
 }
 
-// ListRepos returns all repos accessible to token via /user/repos, following
-// Link header pagination.
-func ListRepos(ctx context.Context, token string) ([]map[string]any, error) {
-	var (
-		all       []map[string]any
-		delay     time.Duration
-		remaining = 5000
-		resetAt   int64
-	)
-	if token != "" {
-		delay = 50 * time.Millisecond
-	} else {
-		delay = 1200 * time.Millisecond
-	}
+// listReposByHandle returns all repos for a given GitHub handle,
+// following pagination.
+func listReposByHandle(ctx context.Context, token, handle string, delay *time.Duration, remaining *int, resetAt *int64) ([]map[string]any, error) {
+	var all []map[string]any
 
-	nextURL := "https://api.github.com/user/repos" +
-		"?per_page=100&sort=pushed&affiliation=owner,collaborator,organization_member"
+	nextURL := fmt.Sprintf("user/repos?per_page=100&sort=pushed&affiliation=owner,collaborator,organization_member&type=all")
+	// For other users' handles (not self), use /users/{handle}/repos
+	// We always use /user/repos for our own handle since it includes private repos.
+	// The caller will filter by handle's repos using the owner field.
+	_ = handle // handled below via owner filter
+
+	// Actually, the right call for "repos a specific person owns/contributes to":
+	// /users/{handle}/repos gives public repos only.
+	// /user/repos with affiliation gives everything you have access to, filtered by owner.
+	// We use /user/repos and filter by owner == handle for private repos of your own,
+	// plus /users/{handle}/repos for other team members' public repos.
+	nextURL = fmt.Sprintf("users/%s/repos?per_page=100&sort=pushed&type=owner", handle)
 
 	for nextURL != "" {
-		if delay > 0 {
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			case <-time.After(delay):
-			}
-		}
-
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, nextURL, nil)
+		body, status, err := ghGet(ctx, token, nextURL, delay, remaining, resetAt)
 		if err != nil {
 			return nil, err
 		}
-		req.Header.Set("Accept", "application/vnd.github.v3+json")
-		if token != "" {
-			req.Header.Set("Authorization", "Bearer "+token)
+		if status == 404 {
+			return nil, nil // handle doesn't exist
 		}
-
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			return nil, err
-		}
-
-		// Track rate limits.
-		if rem := resp.Header.Get("X-RateLimit-Remaining"); rem != "" {
-			if v, e := strconv.Atoi(rem); e == nil {
-				remaining = v
-			}
-		}
-		if reset := resp.Header.Get("X-RateLimit-Reset"); reset != "" {
-			if v, e := strconv.ParseInt(reset, 10, 64); e == nil {
-				resetAt = v
-			}
-		}
-
-		// Adjust delay for next call.
-		if token != "" {
-			switch {
-			case remaining < 20:
-				now := time.Now().Unix()
-				if resetAt > now {
-					delay = time.Duration(resetAt-now+5) * time.Second
-				} else {
-					delay = 50 * time.Millisecond
-				}
-			case remaining < 200:
-				delay = 500 * time.Millisecond
-			default:
-				delay = 50 * time.Millisecond
-			}
-		} else {
-			delay = 1200 * time.Millisecond
-		}
-
-		link := resp.Header.Get("Link")
-		body, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if err != nil {
-			return nil, err
-		}
-
-		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("GitHub API returned %d listing repos", resp.StatusCode)
+		if status != 200 {
+			return nil, fmt.Errorf("HTTP %d listing repos for %s", status, handle)
 		}
 
 		var page []map[string]any
@@ -266,22 +309,42 @@ func ListRepos(ctx context.Context, token string) ([]map[string]any, error) {
 			return nil, err
 		}
 		all = append(all, page...)
-		nextURL = parseNextLink(link)
-	}
 
+		// We'd need the Link header, but ghGet doesn't return it.
+		// For now, 100 repos per handle is sufficient for most team members.
+		// TODO: thread Link header through ghGet if needed.
+		break
+	}
+	return all, nil
+}
+
+// listOwnRepos returns all repos the authenticated user can access (including private).
+// Used only for ExtraHandles that match the token owner.
+func listOwnRepos(ctx context.Context, token string, delay *time.Duration, remaining *int, resetAt *int64) ([]map[string]any, error) {
+	var all []map[string]any
+	nextPath := "user/repos?per_page=100&sort=pushed&affiliation=owner,collaborator,organization_member"
+
+	for nextPath != "" {
+		body, status, err := ghGet(ctx, token, nextPath, delay, remaining, resetAt)
+		if err != nil {
+			return nil, err
+		}
+		if status != 200 {
+			return nil, fmt.Errorf("HTTP %d listing own repos", status)
+		}
+
+		var page []map[string]any
+		if err := json.Unmarshal(body, &page); err != nil {
+			return nil, err
+		}
+		all = append(all, page...)
+		break // one page is enough for now (100 most-recently-pushed)
+	}
 	return all, nil
 }
 
 // ── amplifier detection ───────────────────────────────────────────────────────
 
-// treeIsAmplifierLike returns true when the path list contains amplifier
-// signatures.
-//
-//   - Tier 1 (definitive): bundle.md, bundle.yaml, bundle.yml at root;
-//     any path matching ^behaviors/[^/]+\.yaml$;
-//     any path matching ^agents/[^/]+\.md$;
-//     any path starting with .amplifier/
-//   - Tier 2 (likely): any path matching ^recipes/[^/]+\.yaml$
 func treeIsAmplifierLike(paths []string) bool {
 	tier2 := false
 	for _, p := range paths {
@@ -304,15 +367,12 @@ func treeIsAmplifierLike(paths []string) bool {
 
 // ── capability extraction ─────────────────────────────────────────────────────
 
-// parseFrontmatter extracts the YAML front matter from a markdown string.
-// Returns nil if no front matter is found.
 func parseFrontmatter(content string) map[string]any {
-	// Normalise line endings.
 	content = strings.ReplaceAll(content, "\r\n", "\n")
 	if !strings.HasPrefix(content, "---\n") {
 		return nil
 	}
-	rest := content[4:] // skip "---\n"
+	rest := content[4:]
 	end := strings.Index(rest, "\n---")
 	if end < 0 {
 		return nil
@@ -322,7 +382,6 @@ func parseFrontmatter(content string) map[string]any {
 	return out
 }
 
-// nestedStr walks a nested map using the key path and returns the string value.
 func nestedStr(data map[string]any, keys ...string) string {
 	var cur any = data
 	for _, k := range keys {
@@ -336,15 +395,11 @@ func nestedStr(data map[string]any, keys ...string) string {
 	return s
 }
 
-// readmeDescription extracts the first meaningful prose line from README text.
 func readmeDescription(readme string) string {
 	for _, line := range strings.Split(readme, "\n") {
 		line = strings.TrimSpace(line)
-		if line == "" ||
-			strings.HasPrefix(line, "#") ||
-			strings.HasPrefix(line, "![") ||
-			strings.HasPrefix(line, "[![") ||
-			strings.HasPrefix(line, "<!--") ||
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "![") ||
+			strings.HasPrefix(line, "[![") || strings.HasPrefix(line, "<!--") ||
 			strings.HasPrefix(line, "---") {
 			continue
 		}
@@ -357,8 +412,6 @@ func readmeDescription(readme string) string {
 	return ""
 }
 
-// parsePyprojectTOML extracts the project name and description from a
-// pyproject.toml [project] section.
 func parsePyprojectTOML(content string) (name, desc string) {
 	inProject := false
 	for _, line := range strings.Split(content, "\n") {
@@ -386,15 +439,6 @@ func parsePyprojectTOML(content string) (name, desc string) {
 	return
 }
 
-// ExtractCapabilities reads specific files from the repository via
-// raw.githubusercontent.com and returns detected capabilities.
-//
-// Passes:
-//  1. bundle.md or bundle.yaml/yml — parse YAML/frontmatter, look for bundle.name
-//  2. behaviors/*.yaml — parse YAML, look for bundle.name
-//  3. agents/*.md — parse YAML frontmatter, look for meta.name
-//  4. recipes/*.yaml and .amplifier/recipes/*.yaml — parse YAML, need name AND (steps or stages)
-//  5. pyproject.toml — regex for [project] section, name= and description= fields
 func ExtractCapabilities(owner, repo, branch string, paths []string, readmeText string) ([]Capability, error) {
 	pathSet := make(map[string]bool, len(paths))
 	for _, p := range paths {
@@ -402,29 +446,22 @@ func ExtractCapabilities(owner, repo, branch string, paths []string, readmeText 
 	}
 
 	var caps []Capability
-	var lastErr error
 
-	// ── Pass 1: bundle definition file ──────────────────────────────────────
+	// Pass 1: root bundle file
 	for _, fname := range []string{"bundle.md", "bundle.yaml", "bundle.yml"} {
 		if !pathSet[fname] {
 			continue
 		}
 		content, err := rawFile(owner, repo, branch, fname)
-		if err != nil {
-			lastErr = err
+		if err != nil || content == "" {
 			continue
 		}
-		if content == "" {
-			continue
-		}
-
 		var data map[string]any
 		if strings.HasSuffix(fname, ".md") {
 			data = parseFrontmatter(content)
 		} else {
 			_ = yaml.Unmarshal([]byte(content), &data)
 		}
-
 		name := nestedStr(data, "bundle", "name")
 		if name == "" {
 			break
@@ -440,10 +477,10 @@ func ExtractCapabilities(owner, repo, branch string, paths []string, readmeText 
 			Version:     nestedStr(data, "bundle", "version"),
 			SourceFile:  fname,
 		})
-		break // only the first bundle file
+		break
 	}
 
-	// ── Pass 2: behaviors/*.yaml ─────────────────────────────────────────────
+	// Pass 2: behaviors/*.yaml
 	for _, p := range paths {
 		m := reBehaviors.FindStringSubmatch(p)
 		if m == nil {
@@ -455,10 +492,9 @@ func ExtractCapabilities(owner, repo, branch string, paths []string, readmeText 
 		}
 		var data map[string]any
 		_ = yaml.Unmarshal([]byte(content), &data)
-
 		name := nestedStr(data, "bundle", "name")
 		if name == "" {
-			name = m[1] // fall back to file stem
+			name = m[1]
 		}
 		caps = append(caps, Capability{
 			Type:        "behavior",
@@ -468,7 +504,7 @@ func ExtractCapabilities(owner, repo, branch string, paths []string, readmeText 
 		})
 	}
 
-	// ── Pass 3: agents/*.md ───────────────────────────────────────────────────
+	// Pass 3: agents/*.md
 	for _, p := range paths {
 		m := reAgents.FindStringSubmatch(p)
 		if m == nil {
@@ -479,7 +515,6 @@ func ExtractCapabilities(owner, repo, branch string, paths []string, readmeText 
 			continue
 		}
 		data := parseFrontmatter(content)
-
 		name := nestedStr(data, "meta", "name")
 		if name == "" {
 			name = m[1]
@@ -492,7 +527,7 @@ func ExtractCapabilities(owner, repo, branch string, paths []string, readmeText 
 		})
 	}
 
-	// ── Pass 4: recipes/*.yaml and .amplifier/recipes/*.yaml ─────────────────
+	// Pass 4: recipes
 	for _, p := range paths {
 		var fallback string
 		if m := reRecipes.FindStringSubmatch(p); m != nil {
@@ -502,18 +537,16 @@ func ExtractCapabilities(owner, repo, branch string, paths []string, readmeText 
 		} else {
 			continue
 		}
-
 		content, err := rawFile(owner, repo, branch, p)
 		if err != nil || content == "" {
 			continue
 		}
 		var data map[string]any
 		_ = yaml.Unmarshal([]byte(content), &data)
-
 		name, _ := data["name"].(string)
 		if name == "" {
 			_ = fallback
-			continue // name is required
+			continue
 		}
 		_, hasSteps := data["steps"]
 		_, hasStages := data["stages"]
@@ -527,7 +560,7 @@ func ExtractCapabilities(owner, repo, branch string, paths []string, readmeText 
 		})
 	}
 
-	// ── Pass 5: pyproject.toml ────────────────────────────────────────────────
+	// Pass 5: pyproject.toml
 	if pathSet["pyproject.toml"] {
 		content, err := rawFile(owner, repo, branch, "pyproject.toml")
 		if err == nil && content != "" {
@@ -542,34 +575,32 @@ func ExtractCapabilities(owner, repo, branch string, paths []string, readmeText 
 		}
 	}
 
-	return caps, lastErr
+	return caps, nil
 }
 
-// ── main scan function ────────────────────────────────────────────────────────
+// ── main scan ─────────────────────────────────────────────────────────────────
 
-// Scan scans GitHub repositories and updates the local index and state files.
+// Scan scans repos from sources defined in sources.json and updates the index.
 func Scan(ctx context.Context, dir string, opts ScanOptions) (*ScanResult, error) {
 	token := resolveToken()
+
+	src, err := LoadSources(dir)
+	if err != nil {
+		return nil, fmt.Errorf("loading sources: %w", err)
+	}
+	if len(src.TeamFeeds) == 0 && len(src.ExtraHandles) == 0 && len(src.ExtraRepos) == 0 {
+		return nil, fmt.Errorf(
+			"no sources configured — run: loom index init\n" +
+				"  (creates ~/.amplifier/bundle-index/sources.json)")
+	}
 
 	idx, err := LoadIndex(dir)
 	if err != nil {
 		return nil, fmt.Errorf("loading index: %w", err)
 	}
-
 	st, err := LoadState(dir)
 	if err != nil {
 		return nil, fmt.Errorf("loading state: %w", err)
-	}
-
-	if !opts.Quiet {
-		fmt.Print("Fetching repo list from GitHub... ")
-	}
-	repos, err := ListRepos(ctx, token)
-	if err != nil {
-		return nil, fmt.Errorf("listing repos: %w", err)
-	}
-	if !opts.Quiet {
-		fmt.Printf("found %d repos\n", len(repos))
 	}
 
 	var (
@@ -583,37 +614,91 @@ func Scan(ctx context.Context, dir string, opts ScanOptions) (*ScanResult, error
 		delay = 1200 * time.Millisecond
 	}
 
-	result := &ScanResult{}
+	// ── Resolve handles from team feeds ───────────────────────────────────────
+	if !opts.Quiet {
+		fmt.Print("Resolving team handles... ")
+	}
+	handles, err := resolveHandles(ctx, *src)
+	if err != nil {
+		return nil, err
+	}
+	if !opts.Quiet {
+		fmt.Printf("%d handles from team feeds\n", len(handles))
+	}
 
-	// Build a set of all repo keys for removal detection (key = "org/repo").
-	repoKeys := make(map[string]bool, len(repos))
-	for _, r := range repos {
+	// ── Collect repos from all handles ────────────────────────────────────────
+	// Deduplicate by full_name across handles
+	reposByKey := map[string]map[string]any{}
+
+	// Own repos first (includes private)
+	if !opts.Quiet {
+		fmt.Print("Fetching your repos (including private)... ")
+	}
+	ownRepos, err := listOwnRepos(ctx, token, &delay, &remaining, &resetAt)
+	if err != nil && !opts.Quiet {
+		fmt.Printf("warning: %v\n", err)
+	}
+	for _, r := range ownRepos {
 		if k, ok := r["full_name"].(string); ok && k != "" {
-			repoKeys[k] = true
+			reposByKey[k] = r
+		}
+	}
+	if !opts.Quiet {
+		fmt.Printf("%d repos\n", len(ownRepos))
+	}
+
+	// Team member repos (public only, but that's fine for teammates)
+	for _, handle := range handles {
+		if !opts.Quiet {
+			fmt.Printf("  %s... ", handle)
+		}
+		repos, err := listReposByHandle(ctx, token, handle, &delay, &remaining, &resetAt)
+		if err != nil {
+			if !opts.Quiet {
+				fmt.Printf("error: %v\n", err)
+			}
+			continue
+		}
+		for _, r := range repos {
+			if k, ok := r["full_name"].(string); ok && k != "" {
+				if _, exists := reposByKey[k]; !exists {
+					reposByKey[k] = r
+				}
+			}
+		}
+		if !opts.Quiet {
+			fmt.Printf("%d repos\n", len(repos))
 		}
 	}
 
-	total := len(repos)
-	limit := opts.Limit
-	if limit <= 0 || limit > total {
-		limit = total
+	// Extra specific repos (fetched directly)
+	for _, extraKey := range src.ExtraRepos {
+		if _, exists := reposByKey[extraKey]; exists {
+			continue
+		}
+		body, status, err := ghGet(ctx, token, "repos/"+extraKey, &delay, &remaining, &resetAt)
+		if err != nil || status != 200 {
+			continue
+		}
+		var r map[string]any
+		if json.Unmarshal(body, &r) == nil {
+			reposByKey[extraKey] = r
+		}
 	}
 
 	if !opts.Quiet {
-		fmt.Printf("Scanning %d repos...\n", limit)
+		fmt.Printf("\nScanning %d unique repos for amplifier bundles...\n", len(reposByKey))
 	}
 
-	for i, repo := range repos {
-		if i >= limit {
-			break
-		}
+	result := &ScanResult{}
 
-		key, _ := repo["full_name"].(string)
-		if key == "" {
-			continue
-		}
+	// Track which keys we saw (for removal detection)
+	seenKeys := map[string]bool{}
+	for k := range reposByKey {
+		seenKeys[k] = true
+	}
 
-		// Skip archived repos unless requested.
+	for key, repo := range reposByKey {
 		archived, _ := repo["archived"].(bool)
 		if archived && !opts.IncludeArchived {
 			result.Skipped++
@@ -628,26 +713,20 @@ func Scan(ctx context.Context, dir string, opts ScanOptions) (*ScanResult, error
 
 		cached := st.Repos[key]
 
-		// ── Gate 1: pushed_at unchanged ────────────────────────────────────
+		// Gate 1: pushed_at unchanged
 		if pushedAt != "" && cached.PushedAt == pushedAt && !opts.Force {
 			if cached.AmplifierLike {
 				result.Unchanged++
 			} else {
 				result.Skipped++
 			}
-			if !opts.Quiet {
-				fmt.Printf("  [%d/%d] %s (unchanged)\n", i+1, limit, key)
-			}
 			continue
 		}
 
-		// ── Fetch git tree ──────────────────────────────────────────────────
+		// Fetch git tree
 		treePath := fmt.Sprintf("repos/%s/git/trees/%s?recursive=1", key, defaultBranch)
 		treeBody, status, err := ghGet(ctx, token, treePath, &delay, &remaining, &resetAt)
 		if err != nil {
-			if !opts.Quiet {
-				fmt.Printf("  [%d/%d] %s (error: %v)\n", i+1, limit, key, err)
-			}
 			result.Skipped++
 			continue
 		}
@@ -681,7 +760,7 @@ func Scan(ctx context.Context, dir string, opts ScanOptions) (*ScanResult, error
 			paths = append(paths, t.Path)
 		}
 
-		// ── Gate 2: tree SHA unchanged ─────────────────────────────────────
+		// Gate 2: tree SHA unchanged
 		if treeSha != "" && cached.TreeSha == treeSha && !opts.Force {
 			st.Repos[key] = RepoState{
 				PushedAt:      pushedAt,
@@ -693,13 +772,10 @@ func Scan(ctx context.Context, dir string, opts ScanOptions) (*ScanResult, error
 			} else {
 				result.Skipped++
 			}
-			if !opts.Quiet {
-				fmt.Printf("  [%d/%d] %s (tree unchanged)\n", i+1, limit, key)
-			}
 			continue
 		}
 
-		// ── Amplifier-like check ───────────────────────────────────────────
+		// Check amplifier signatures
 		isAmplifier := treeIsAmplifierLike(paths)
 		st.Repos[key] = RepoState{
 			PushedAt:      pushedAt,
@@ -708,27 +784,21 @@ func Scan(ctx context.Context, dir string, opts ScanOptions) (*ScanResult, error
 		}
 
 		if !isAmplifier {
-			if _, exists := idx.Repos[key]; exists {
+			if _, existed := idx.Repos[key]; existed {
 				result.Removed = append(result.Removed, key)
 				delete(idx.Repos, key)
 			} else {
 				result.Skipped++
 			}
-			if !opts.Quiet {
-				fmt.Printf("  [%d/%d] %s (not amplifier)\n", i+1, limit, key)
-			}
 			continue
 		}
 
-		// ── Fetch README for description fallback ──────────────────────────
+		// Extract capabilities
 		parts := strings.SplitN(key, "/", 2)
 		ownerName, repoName := parts[0], parts[1]
 		readmeText, _ := rawFile(ownerName, repoName, defaultBranch, "README.md")
-
-		// ── Extract capabilities ────────────────────────────────────────────
 		caps, _ := ExtractCapabilities(ownerName, repoName, defaultBranch, paths, readmeText)
 
-		// ── Build entry ────────────────────────────────────────────────────
 		name, _ := repo["name"].(string)
 		desc, _ := repo["description"].(string)
 		if desc == "" {
@@ -736,6 +806,7 @@ func Scan(ctx context.Context, dir string, opts ScanOptions) (*ScanResult, error
 		}
 		stars, _ := repo["stargazers_count"].(float64)
 		private, _ := repo["private"].(bool)
+
 		topicsAny, _ := repo["topics"].([]any)
 		topics := make([]string, 0, len(topicsAny))
 		for _, t := range topicsAny {
@@ -752,12 +823,9 @@ func Scan(ctx context.Context, dir string, opts ScanOptions) (*ScanResult, error
 			Stars:         int(stars),
 			Private:       private,
 			Topics:        topics,
-			Install: fmt.Sprintf(
-				"amplifier bundle add git+https://github.com/%s@%s",
-				key, defaultBranch,
-			),
-			Capabilities: caps,
-			ScannedAt:    time.Now().UTC().Format(time.RFC3339),
+			Install:       fmt.Sprintf("amplifier bundle add git+https://github.com/%s@%s", key, defaultBranch),
+			Capabilities:  caps,
+			ScannedAt:     time.Now().UTC().Format(time.RFC3339),
 		}
 
 		_, existed := idx.Repos[key]
@@ -766,25 +834,24 @@ func Scan(ctx context.Context, dir string, opts ScanOptions) (*ScanResult, error
 		if existed {
 			result.Updated = append(result.Updated, entry)
 			if !opts.Quiet {
-				fmt.Printf("  [%d/%d] %s → updated\n", i+1, limit, key)
+				fmt.Printf("  ~ %s (updated)\n", key)
 			}
 		} else {
 			result.Added = append(result.Added, entry)
 			if !opts.Quiet {
-				fmt.Printf("  [%d/%d] %s → added\n", i+1, limit, key)
+				fmt.Printf("  + %s\n", key)
 			}
 		}
 	}
 
-	// ── Detect repos removed from GitHub ─────────────────────────────────────
+	// Remove repos no longer in any source
 	for k := range idx.Repos {
-		if !repoKeys[k] {
+		if !seenKeys[k] {
 			result.Removed = append(result.Removed, k)
 			delete(idx.Repos, k)
 		}
 	}
 
-	// ── Finalise and save ─────────────────────────────────────────────────────
 	idx.LastScan = time.Now().UTC().Format(time.RFC3339)
 	idx.Version = 1
 	st.Version = 1

--- a/internal/index/scanner.go
+++ b/internal/index/scanner.go
@@ -1,0 +1,802 @@
+package index
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ScanOptions controls how Scan operates.
+type ScanOptions struct {
+	Limit           int  // 0 = unlimited
+	Force           bool // re-scan even if pushed_at unchanged
+	IncludeArchived bool
+	Quiet           bool
+}
+
+// ScanResult summarises what changed during a Scan run.
+type ScanResult struct {
+	Added        []Entry
+	Updated      []Entry
+	Removed      []string // remote keys ("org/repo") removed from the index
+	Unchanged    int
+	Skipped      int
+	APIRemaining int
+}
+
+// ── package-level compiled regexps ──────────────────────────────────────────
+
+var (
+	reBehaviors = regexp.MustCompile(`^behaviors/([^/]+)\.yaml$`)
+	reAgents    = regexp.MustCompile(`^agents/([^/]+)\.md$`)
+	reRecipes   = regexp.MustCompile(`^recipes/([^/]+)\.yaml$`)
+	reAmpRecipes = regexp.MustCompile(`^\.amplifier/recipes/([^/]+)\.yaml$`)
+	rePySection  = regexp.MustCompile(`^\[([^\]]+)\]`)
+	rePyName     = regexp.MustCompile(`^name\s*=\s*"([^"]*)"`)
+	rePyDesc     = regexp.MustCompile(`^description\s*=\s*"([^"]*)"`)
+)
+
+// ── token resolution ─────────────────────────────────────────────────────────
+
+// resolveToken returns: GITHUB_TOKEN env var → gh auth token → empty string.
+func resolveToken() string {
+	if tok := os.Getenv("GITHUB_TOKEN"); tok != "" {
+		return tok
+	}
+	out, err := exec.Command("gh", "auth", "token").Output()
+	if err == nil {
+		if tok := strings.TrimSpace(string(out)); tok != "" {
+			return tok
+		}
+	}
+	return ""
+}
+
+// ── GitHub API helper ────────────────────────────────────────────────────────
+
+// ghGet makes a GET request to https://api.github.com/{path}.
+// It sleeps *delay before the request, then updates *remaining/*resetAt from
+// X-RateLimit-* response headers and adjusts *delay for the next call.
+// Returns (nil, 304, nil) for 304 Not Modified.
+func ghGet(ctx context.Context, token, path string, delay *time.Duration, remaining *int, resetAt *int64) ([]byte, int, error) {
+	if *delay > 0 {
+		select {
+		case <-ctx.Done():
+			return nil, 0, ctx.Err()
+		case <-time.After(*delay):
+		}
+	}
+
+	url := "https://api.github.com/" + strings.TrimPrefix(path, "/")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	// Track rate limits.
+	if rem := resp.Header.Get("X-RateLimit-Remaining"); rem != "" {
+		if v, e := strconv.Atoi(rem); e == nil {
+			*remaining = v
+		}
+	}
+	if reset := resp.Header.Get("X-RateLimit-Reset"); reset != "" {
+		if v, e := strconv.ParseInt(reset, 10, 64); e == nil {
+			*resetAt = v
+		}
+	}
+
+	// Adjust delay for next call.
+	if token != "" {
+		switch {
+		case *remaining < 20:
+			now := time.Now().Unix()
+			if *resetAt > now {
+				*delay = time.Duration(*resetAt-now+5) * time.Second
+			} else {
+				*delay = 50 * time.Millisecond
+			}
+		case *remaining < 200:
+			*delay = 500 * time.Millisecond
+		default:
+			*delay = 50 * time.Millisecond
+		}
+	} else {
+		*delay = 1200 * time.Millisecond
+	}
+
+	if resp.StatusCode == http.StatusNotModified {
+		return nil, 304, nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, err
+	}
+	return body, resp.StatusCode, nil
+}
+
+// ── raw file fetch (no quota) ─────────────────────────────────────────────────
+
+// rawFile fetches a raw file from raw.githubusercontent.com.
+// Returns ("", nil) if the file is not found.
+func rawFile(owner, repo, branch, path string) (string, error) {
+	url := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s",
+		owner, repo, branch, path)
+	resp, err := http.Get(url) //nolint:noctx
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusForbidden {
+		return "", nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", nil
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+// ── GitHub API pagination ─────────────────────────────────────────────────────
+
+// parseNextLink extracts the "next" URL from a GitHub Link header.
+func parseNextLink(header string) string {
+	for _, part := range strings.Split(header, ",") {
+		part = strings.TrimSpace(part)
+		segs := strings.SplitN(part, ";", 2)
+		if len(segs) != 2 {
+			continue
+		}
+		if strings.TrimSpace(segs[1]) == `rel="next"` {
+			u := strings.TrimSpace(segs[0])
+			return strings.Trim(u, "<>")
+		}
+	}
+	return ""
+}
+
+// ListRepos returns all repos accessible to token via /user/repos, following
+// Link header pagination.
+func ListRepos(ctx context.Context, token string) ([]map[string]any, error) {
+	var (
+		all       []map[string]any
+		delay     time.Duration
+		remaining = 5000
+		resetAt   int64
+	)
+	if token != "" {
+		delay = 50 * time.Millisecond
+	} else {
+		delay = 1200 * time.Millisecond
+	}
+
+	nextURL := "https://api.github.com/user/repos" +
+		"?per_page=100&sort=pushed&affiliation=owner,collaborator,organization_member"
+
+	for nextURL != "" {
+		if delay > 0 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, nextURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Accept", "application/vnd.github.v3+json")
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		// Track rate limits.
+		if rem := resp.Header.Get("X-RateLimit-Remaining"); rem != "" {
+			if v, e := strconv.Atoi(rem); e == nil {
+				remaining = v
+			}
+		}
+		if reset := resp.Header.Get("X-RateLimit-Reset"); reset != "" {
+			if v, e := strconv.ParseInt(reset, 10, 64); e == nil {
+				resetAt = v
+			}
+		}
+
+		// Adjust delay for next call.
+		if token != "" {
+			switch {
+			case remaining < 20:
+				now := time.Now().Unix()
+				if resetAt > now {
+					delay = time.Duration(resetAt-now+5) * time.Second
+				} else {
+					delay = 50 * time.Millisecond
+				}
+			case remaining < 200:
+				delay = 500 * time.Millisecond
+			default:
+				delay = 50 * time.Millisecond
+			}
+		} else {
+			delay = 1200 * time.Millisecond
+		}
+
+		link := resp.Header.Get("Link")
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("GitHub API returned %d listing repos", resp.StatusCode)
+		}
+
+		var page []map[string]any
+		if err := json.Unmarshal(body, &page); err != nil {
+			return nil, err
+		}
+		all = append(all, page...)
+		nextURL = parseNextLink(link)
+	}
+
+	return all, nil
+}
+
+// ── amplifier detection ───────────────────────────────────────────────────────
+
+// treeIsAmplifierLike returns true when the path list contains amplifier
+// signatures.
+//
+//   - Tier 1 (definitive): bundle.md, bundle.yaml, bundle.yml at root;
+//     any path matching ^behaviors/[^/]+\.yaml$;
+//     any path matching ^agents/[^/]+\.md$;
+//     any path starting with .amplifier/
+//   - Tier 2 (likely): any path matching ^recipes/[^/]+\.yaml$
+func treeIsAmplifierLike(paths []string) bool {
+	tier2 := false
+	for _, p := range paths {
+		switch p {
+		case "bundle.md", "bundle.yaml", "bundle.yml":
+			return true
+		}
+		if strings.HasPrefix(p, ".amplifier/") {
+			return true
+		}
+		if reBehaviors.MatchString(p) || reAgents.MatchString(p) {
+			return true
+		}
+		if reRecipes.MatchString(p) {
+			tier2 = true
+		}
+	}
+	return tier2
+}
+
+// ── capability extraction ─────────────────────────────────────────────────────
+
+// parseFrontmatter extracts the YAML front matter from a markdown string.
+// Returns nil if no front matter is found.
+func parseFrontmatter(content string) map[string]any {
+	// Normalise line endings.
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	if !strings.HasPrefix(content, "---\n") {
+		return nil
+	}
+	rest := content[4:] // skip "---\n"
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return nil
+	}
+	var out map[string]any
+	_ = yaml.Unmarshal([]byte(rest[:end]), &out)
+	return out
+}
+
+// nestedStr walks a nested map using the key path and returns the string value.
+func nestedStr(data map[string]any, keys ...string) string {
+	var cur any = data
+	for _, k := range keys {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return ""
+		}
+		cur = m[k]
+	}
+	s, _ := cur.(string)
+	return s
+}
+
+// readmeDescription extracts the first meaningful prose line from README text.
+func readmeDescription(readme string) string {
+	for _, line := range strings.Split(readme, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" ||
+			strings.HasPrefix(line, "#") ||
+			strings.HasPrefix(line, "![") ||
+			strings.HasPrefix(line, "[![") ||
+			strings.HasPrefix(line, "<!--") ||
+			strings.HasPrefix(line, "---") {
+			continue
+		}
+		runes := []rune(line)
+		if len(runes) > 200 {
+			runes = runes[:200]
+		}
+		return string(runes)
+	}
+	return ""
+}
+
+// parsePyprojectTOML extracts the project name and description from a
+// pyproject.toml [project] section.
+func parsePyprojectTOML(content string) (name, desc string) {
+	inProject := false
+	for _, line := range strings.Split(content, "\n") {
+		if m := rePySection.FindStringSubmatch(line); m != nil {
+			inProject = m[1] == "project"
+			continue
+		}
+		if !inProject {
+			continue
+		}
+		if name == "" {
+			if m := rePyName.FindStringSubmatch(line); m != nil {
+				name = m[1]
+			}
+		}
+		if desc == "" {
+			if m := rePyDesc.FindStringSubmatch(line); m != nil {
+				desc = m[1]
+			}
+		}
+		if name != "" && desc != "" {
+			break
+		}
+	}
+	return
+}
+
+// ExtractCapabilities reads specific files from the repository via
+// raw.githubusercontent.com and returns detected capabilities.
+//
+// Passes:
+//  1. bundle.md or bundle.yaml/yml — parse YAML/frontmatter, look for bundle.name
+//  2. behaviors/*.yaml — parse YAML, look for bundle.name
+//  3. agents/*.md — parse YAML frontmatter, look for meta.name
+//  4. recipes/*.yaml and .amplifier/recipes/*.yaml — parse YAML, need name AND (steps or stages)
+//  5. pyproject.toml — regex for [project] section, name= and description= fields
+func ExtractCapabilities(owner, repo, branch string, paths []string, readmeText string) ([]Capability, error) {
+	pathSet := make(map[string]bool, len(paths))
+	for _, p := range paths {
+		pathSet[p] = true
+	}
+
+	var caps []Capability
+	var lastErr error
+
+	// ── Pass 1: bundle definition file ──────────────────────────────────────
+	for _, fname := range []string{"bundle.md", "bundle.yaml", "bundle.yml"} {
+		if !pathSet[fname] {
+			continue
+		}
+		content, err := rawFile(owner, repo, branch, fname)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if content == "" {
+			continue
+		}
+
+		var data map[string]any
+		if strings.HasSuffix(fname, ".md") {
+			data = parseFrontmatter(content)
+		} else {
+			_ = yaml.Unmarshal([]byte(content), &data)
+		}
+
+		name := nestedStr(data, "bundle", "name")
+		if name == "" {
+			break
+		}
+		desc := nestedStr(data, "bundle", "description")
+		if desc == "" {
+			desc = readmeDescription(readmeText)
+		}
+		caps = append(caps, Capability{
+			Type:        "bundle",
+			Name:        name,
+			Description: desc,
+			Version:     nestedStr(data, "bundle", "version"),
+			SourceFile:  fname,
+		})
+		break // only the first bundle file
+	}
+
+	// ── Pass 2: behaviors/*.yaml ─────────────────────────────────────────────
+	for _, p := range paths {
+		m := reBehaviors.FindStringSubmatch(p)
+		if m == nil {
+			continue
+		}
+		content, err := rawFile(owner, repo, branch, p)
+		if err != nil || content == "" {
+			continue
+		}
+		var data map[string]any
+		_ = yaml.Unmarshal([]byte(content), &data)
+
+		name := nestedStr(data, "bundle", "name")
+		if name == "" {
+			name = m[1] // fall back to file stem
+		}
+		caps = append(caps, Capability{
+			Type:        "behavior",
+			Name:        name,
+			Description: nestedStr(data, "bundle", "description"),
+			SourceFile:  p,
+		})
+	}
+
+	// ── Pass 3: agents/*.md ───────────────────────────────────────────────────
+	for _, p := range paths {
+		m := reAgents.FindStringSubmatch(p)
+		if m == nil {
+			continue
+		}
+		content, err := rawFile(owner, repo, branch, p)
+		if err != nil || content == "" {
+			continue
+		}
+		data := parseFrontmatter(content)
+
+		name := nestedStr(data, "meta", "name")
+		if name == "" {
+			name = m[1]
+		}
+		caps = append(caps, Capability{
+			Type:        "agent",
+			Name:        name,
+			Description: nestedStr(data, "meta", "description"),
+			SourceFile:  p,
+		})
+	}
+
+	// ── Pass 4: recipes/*.yaml and .amplifier/recipes/*.yaml ─────────────────
+	for _, p := range paths {
+		var fallback string
+		if m := reRecipes.FindStringSubmatch(p); m != nil {
+			fallback = m[1]
+		} else if m := reAmpRecipes.FindStringSubmatch(p); m != nil {
+			fallback = m[1]
+		} else {
+			continue
+		}
+
+		content, err := rawFile(owner, repo, branch, p)
+		if err != nil || content == "" {
+			continue
+		}
+		var data map[string]any
+		_ = yaml.Unmarshal([]byte(content), &data)
+
+		name, _ := data["name"].(string)
+		if name == "" {
+			_ = fallback
+			continue // name is required
+		}
+		_, hasSteps := data["steps"]
+		_, hasStages := data["stages"]
+		if !hasSteps && !hasStages {
+			continue
+		}
+		caps = append(caps, Capability{
+			Type:       "recipe",
+			Name:       name,
+			SourceFile: p,
+		})
+	}
+
+	// ── Pass 5: pyproject.toml ────────────────────────────────────────────────
+	if pathSet["pyproject.toml"] {
+		content, err := rawFile(owner, repo, branch, "pyproject.toml")
+		if err == nil && content != "" {
+			if pName, pDesc := parsePyprojectTOML(content); pName != "" {
+				caps = append(caps, Capability{
+					Type:        "package",
+					Name:        pName,
+					Description: pDesc,
+					SourceFile:  "pyproject.toml",
+				})
+			}
+		}
+	}
+
+	return caps, lastErr
+}
+
+// ── main scan function ────────────────────────────────────────────────────────
+
+// Scan scans GitHub repositories and updates the local index and state files.
+func Scan(ctx context.Context, dir string, opts ScanOptions) (*ScanResult, error) {
+	token := resolveToken()
+
+	idx, err := LoadIndex(dir)
+	if err != nil {
+		return nil, fmt.Errorf("loading index: %w", err)
+	}
+
+	st, err := LoadState(dir)
+	if err != nil {
+		return nil, fmt.Errorf("loading state: %w", err)
+	}
+
+	if !opts.Quiet {
+		fmt.Print("Fetching repo list from GitHub... ")
+	}
+	repos, err := ListRepos(ctx, token)
+	if err != nil {
+		return nil, fmt.Errorf("listing repos: %w", err)
+	}
+	if !opts.Quiet {
+		fmt.Printf("found %d repos\n", len(repos))
+	}
+
+	var (
+		delay     time.Duration
+		remaining = 5000
+		resetAt   int64
+	)
+	if token != "" {
+		delay = 50 * time.Millisecond
+	} else {
+		delay = 1200 * time.Millisecond
+	}
+
+	result := &ScanResult{}
+
+	// Build a set of all repo keys for removal detection (key = "org/repo").
+	repoKeys := make(map[string]bool, len(repos))
+	for _, r := range repos {
+		if k, ok := r["full_name"].(string); ok && k != "" {
+			repoKeys[k] = true
+		}
+	}
+
+	total := len(repos)
+	limit := opts.Limit
+	if limit <= 0 || limit > total {
+		limit = total
+	}
+
+	if !opts.Quiet {
+		fmt.Printf("Scanning %d repos...\n", limit)
+	}
+
+	for i, repo := range repos {
+		if i >= limit {
+			break
+		}
+
+		key, _ := repo["full_name"].(string)
+		if key == "" {
+			continue
+		}
+
+		// Skip archived repos unless requested.
+		archived, _ := repo["archived"].(bool)
+		if archived && !opts.IncludeArchived {
+			result.Skipped++
+			continue
+		}
+
+		pushedAt, _ := repo["pushed_at"].(string)
+		defaultBranch, _ := repo["default_branch"].(string)
+		if defaultBranch == "" {
+			defaultBranch = "main"
+		}
+
+		cached := st.Repos[key]
+
+		// ── Gate 1: pushed_at unchanged ────────────────────────────────────
+		if pushedAt != "" && cached.PushedAt == pushedAt && !opts.Force {
+			if cached.AmplifierLike {
+				result.Unchanged++
+			} else {
+				result.Skipped++
+			}
+			if !opts.Quiet {
+				fmt.Printf("  [%d/%d] %s (unchanged)\n", i+1, limit, key)
+			}
+			continue
+		}
+
+		// ── Fetch git tree ──────────────────────────────────────────────────
+		treePath := fmt.Sprintf("repos/%s/git/trees/%s?recursive=1", key, defaultBranch)
+		treeBody, status, err := ghGet(ctx, token, treePath, &delay, &remaining, &resetAt)
+		if err != nil {
+			if !opts.Quiet {
+				fmt.Printf("  [%d/%d] %s (error: %v)\n", i+1, limit, key, err)
+			}
+			result.Skipped++
+			continue
+		}
+		switch status {
+		case 409: // empty repo
+			st.Repos[key] = RepoState{PushedAt: pushedAt, AmplifierLike: false}
+			result.Skipped++
+			continue
+		case 403, 404:
+			result.Skipped++
+			continue
+		}
+		if status != 200 {
+			result.Skipped++
+			continue
+		}
+
+		var treeResp struct {
+			SHA  string `json:"sha"`
+			Tree []struct {
+				Path string `json:"path"`
+			} `json:"tree"`
+		}
+		if err := json.Unmarshal(treeBody, &treeResp); err != nil {
+			result.Skipped++
+			continue
+		}
+		treeSha := treeResp.SHA
+		paths := make([]string, 0, len(treeResp.Tree))
+		for _, t := range treeResp.Tree {
+			paths = append(paths, t.Path)
+		}
+
+		// ── Gate 2: tree SHA unchanged ─────────────────────────────────────
+		if treeSha != "" && cached.TreeSha == treeSha && !opts.Force {
+			st.Repos[key] = RepoState{
+				PushedAt:      pushedAt,
+				TreeSha:       cached.TreeSha,
+				AmplifierLike: cached.AmplifierLike,
+			}
+			if cached.AmplifierLike {
+				result.Unchanged++
+			} else {
+				result.Skipped++
+			}
+			if !opts.Quiet {
+				fmt.Printf("  [%d/%d] %s (tree unchanged)\n", i+1, limit, key)
+			}
+			continue
+		}
+
+		// ── Amplifier-like check ───────────────────────────────────────────
+		isAmplifier := treeIsAmplifierLike(paths)
+		st.Repos[key] = RepoState{
+			PushedAt:      pushedAt,
+			TreeSha:       treeSha,
+			AmplifierLike: isAmplifier,
+		}
+
+		if !isAmplifier {
+			if _, exists := idx.Repos[key]; exists {
+				result.Removed = append(result.Removed, key)
+				delete(idx.Repos, key)
+			} else {
+				result.Skipped++
+			}
+			if !opts.Quiet {
+				fmt.Printf("  [%d/%d] %s (not amplifier)\n", i+1, limit, key)
+			}
+			continue
+		}
+
+		// ── Fetch README for description fallback ──────────────────────────
+		parts := strings.SplitN(key, "/", 2)
+		ownerName, repoName := parts[0], parts[1]
+		readmeText, _ := rawFile(ownerName, repoName, defaultBranch, "README.md")
+
+		// ── Extract capabilities ────────────────────────────────────────────
+		caps, _ := ExtractCapabilities(ownerName, repoName, defaultBranch, paths, readmeText)
+
+		// ── Build entry ────────────────────────────────────────────────────
+		name, _ := repo["name"].(string)
+		desc, _ := repo["description"].(string)
+		if desc == "" {
+			desc = readmeDescription(readmeText)
+		}
+		stars, _ := repo["stargazers_count"].(float64)
+		private, _ := repo["private"].(bool)
+		topicsAny, _ := repo["topics"].([]any)
+		topics := make([]string, 0, len(topicsAny))
+		for _, t := range topicsAny {
+			if s, ok := t.(string); ok {
+				topics = append(topics, s)
+			}
+		}
+
+		entry := Entry{
+			Remote:        key,
+			Name:          name,
+			Description:   desc,
+			DefaultBranch: defaultBranch,
+			Stars:         int(stars),
+			Private:       private,
+			Topics:        topics,
+			Install: fmt.Sprintf(
+				"amplifier bundle add git+https://github.com/%s@%s",
+				key, defaultBranch,
+			),
+			Capabilities: caps,
+			ScannedAt:    time.Now().UTC().Format(time.RFC3339),
+		}
+
+		_, existed := idx.Repos[key]
+		idx.Repos[key] = entry
+
+		if existed {
+			result.Updated = append(result.Updated, entry)
+			if !opts.Quiet {
+				fmt.Printf("  [%d/%d] %s → updated\n", i+1, limit, key)
+			}
+		} else {
+			result.Added = append(result.Added, entry)
+			if !opts.Quiet {
+				fmt.Printf("  [%d/%d] %s → added\n", i+1, limit, key)
+			}
+		}
+	}
+
+	// ── Detect repos removed from GitHub ─────────────────────────────────────
+	for k := range idx.Repos {
+		if !repoKeys[k] {
+			result.Removed = append(result.Removed, k)
+			delete(idx.Repos, k)
+		}
+	}
+
+	// ── Finalise and save ─────────────────────────────────────────────────────
+	idx.LastScan = time.Now().UTC().Format(time.RFC3339)
+	idx.Version = 1
+	st.Version = 1
+	st.RateLimit = &RateLimitInfo{Remaining: remaining, ResetAt: resetAt}
+	result.APIRemaining = remaining
+
+	if err := SaveIndex(dir, idx); err != nil {
+		return nil, fmt.Errorf("saving index: %w", err)
+	}
+	if err := SaveState(dir, st); err != nil {
+		return nil, fmt.Errorf("saving state: %w", err)
+	}
+
+	return result, nil
+}

--- a/internal/index/scanner.go
+++ b/internal/index/scanner.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -145,7 +146,35 @@ var (
 	rePyDesc     = regexp.MustCompile(`^description\s*=\s*"([^"]*)"`)
 )
 
-// ── token resolution ──────────────────────────────────────────────────────────
+// ── rate limiter ──────────────────────────────────────────────────────────────
+// rateLimiter serialises GitHub API calls so concurrent workers don't race
+// on the delay/remaining/resetAt state.
+
+type rateLimiter struct {
+	mu        sync.Mutex
+	delay     time.Duration
+	remaining int
+	resetAt   int64
+}
+
+func newRateLimiter(token string) *rateLimiter {
+	rl := &rateLimiter{remaining: 5000}
+	if token != "" {
+		rl.delay = 50 * time.Millisecond
+	} else {
+		rl.delay = 1200 * time.Millisecond
+	}
+	return rl
+}
+
+// call executes ghGet under the rate limiter lock.
+func (rl *rateLimiter) call(ctx context.Context, token, path string) ([]byte, int, error) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	return ghGet(ctx, token, path, &rl.delay, &rl.remaining, &rl.resetAt)
+}
+
+// ── token resolution ────────────────────────────────────────────────────────────
 
 func resolveToken() string {
 	if tok := os.Getenv("GITHUB_TOKEN"); tok != "" {
@@ -719,148 +748,196 @@ func Scan(ctx context.Context, dir string, opts ScanOptions) (*ScanResult, error
 		seenKeys[k] = true
 	}
 
+	// ── Parallel repo scan ──────────────────────────────────────────────────────
+	// Gate 1 (pushed_at) is checked without any API call — pure local state.
+	// Gate 2 + extraction require one ghGet (tree) + raw file reads per repo.
+	// Workers share a rateLimiter that serialises ghGet calls while letting
+	// raw file reads (rawFile / ExtractCapabilities) run fully concurrently.
+
+	const workers = 8
+
+	rl := newRateLimiter(token)
+
+	type repoWork struct {
+		key  string
+		repo map[string]any
+	}
+	type repoOutcome struct {
+		key     string
+		action  string // "added", "updated", "removed", "unchanged", "skip"
+		entry   *Entry
+		state   *RepoState
+		prevKey string // for "removed"
+	}
+
+	workCh := make(chan repoWork, len(reposByKey))
+	outCh  := make(chan repoOutcome, len(reposByKey))
+
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for w := range workCh {
+				key := w.key
+				repo := w.repo
+
+				archived, _ := repo["archived"].(bool)
+				if archived && !opts.IncludeArchived {
+					outCh <- repoOutcome{key: key, action: "skip"}
+					continue
+				}
+
+				pushedAt, _ := repo["pushed_at"].(string)
+				defaultBranch, _ := repo["default_branch"].(string)
+				if defaultBranch == "" {
+					defaultBranch = "main"
+				}
+
+				// Read cached state (safe — read-only at this point)
+				cached := st.Repos[key]
+
+				// Gate 1: pushed_at unchanged — no API call
+				if pushedAt != "" && cached.PushedAt == pushedAt && !opts.Force {
+					action := "skip"
+					if cached.AmplifierLike {
+						action = "unchanged"
+					}
+					outCh <- repoOutcome{key: key, action: action}
+					continue
+				}
+
+				// Gate 2: fetch tree (serialised through rate limiter)
+				treePath := fmt.Sprintf("repos/%s/git/trees/%s?recursive=1", key, defaultBranch)
+				treeBody, status, err := rl.call(ctx, token, treePath)
+				if err != nil {
+					outCh <- repoOutcome{key: key, action: "skip"}
+					continue
+				}
+				switch status {
+				case 409, 403, 404:
+					rs := RepoState{PushedAt: pushedAt, AmplifierLike: false}
+					outCh <- repoOutcome{key: key, action: "skip", state: &rs}
+					continue
+				}
+				if status != 200 {
+					outCh <- repoOutcome{key: key, action: "skip"}
+					continue
+				}
+
+				var treeResp struct {
+					SHA  string `json:"sha"`
+					Tree []struct {
+						Path string `json:"path"`
+					} `json:"tree"`
+				}
+				if err := json.Unmarshal(treeBody, &treeResp); err != nil {
+					outCh <- repoOutcome{key: key, action: "skip"}
+					continue
+				}
+				treeSha := treeResp.SHA
+				paths := make([]string, 0, len(treeResp.Tree))
+				for _, t := range treeResp.Tree {
+					paths = append(paths, t.Path)
+				}
+
+				// Tree SHA gate
+				if treeSha != "" && cached.TreeSha == treeSha && !opts.Force {
+					rs := RepoState{PushedAt: pushedAt, TreeSha: cached.TreeSha, AmplifierLike: cached.AmplifierLike}
+					action := "skip"
+					if cached.AmplifierLike {
+						action = "unchanged"
+					}
+					outCh <- repoOutcome{key: key, action: action, state: &rs}
+					continue
+				}
+
+				// Amplifier detection
+				isAmplifier := treeIsAmplifierLike(paths)
+				newState := &RepoState{PushedAt: pushedAt, TreeSha: treeSha, AmplifierLike: isAmplifier}
+
+				if !isAmplifier {
+					outCh <- repoOutcome{key: key, action: "removed", state: newState}
+					continue
+				}
+
+				// File reads — fully parallel, no shared state (rawFile is pure HTTP)
+				parts := strings.SplitN(key, "/", 2)
+				ownerName, repoName := parts[0], parts[1]
+				readmeText, _ := rawFile(token, ownerName, repoName, defaultBranch, "README.md")
+				caps, _ := ExtractCapabilities(token, ownerName, repoName, defaultBranch, paths, readmeText)
+
+				name, _ := repo["name"].(string)
+				desc, _ := repo["description"].(string)
+				if desc == "" {
+					desc = readmeDescription(readmeText)
+				}
+				stars, _ := repo["stargazers_count"].(float64)
+				private, _ := repo["private"].(bool)
+				topicsAny, _ := repo["topics"].([]any)
+				topics := make([]string, 0, len(topicsAny))
+				for _, t := range topicsAny {
+					if s, ok := t.(string); ok {
+						topics = append(topics, s)
+					}
+				}
+
+				entry := Entry{
+					Remote:        key,
+					Name:          name,
+					Description:   desc,
+					DefaultBranch: defaultBranch,
+					Stars:         int(stars),
+					Private:       private,
+					Topics:        topics,
+					Install:       fmt.Sprintf("amplifier bundle add git+https://github.com/%s@%s", key, defaultBranch),
+					Capabilities:  caps,
+					ScannedAt:     time.Now().UTC().Format(time.RFC3339),
+				}
+				outCh <- repoOutcome{key: key, action: "upsert", entry: &entry, state: newState}
+			}
+		}()
+	}
+
+	// Feed workers
 	for key, repo := range reposByKey {
-		archived, _ := repo["archived"].(bool)
-		if archived && !opts.IncludeArchived {
+		workCh <- repoWork{key: key, repo: repo}
+	}
+	close(workCh)
+
+	// Close output channel once all workers finish
+	go func() { wg.Wait(); close(outCh) }()
+
+	// Collect results (single goroutine — no mutex needed on idx/st/result)
+	for out := range outCh {
+		if out.state != nil {
+			st.Repos[out.key] = *out.state
+		}
+		switch out.action {
+		case "unchanged":
+			result.Unchanged++
+		case "skip":
 			result.Skipped++
-			continue
-		}
-
-		pushedAt, _ := repo["pushed_at"].(string)
-		defaultBranch, _ := repo["default_branch"].(string)
-		if defaultBranch == "" {
-			defaultBranch = "main"
-		}
-
-		cached := st.Repos[key]
-
-		// Gate 1: pushed_at unchanged
-		if pushedAt != "" && cached.PushedAt == pushedAt && !opts.Force {
-			if cached.AmplifierLike {
-				result.Unchanged++
+		case "removed":
+			if _, existed := idx.Repos[out.key]; existed {
+				result.Removed = append(result.Removed, out.key)
+				delete(idx.Repos, out.key)
 			} else {
 				result.Skipped++
 			}
-			continue
-		}
-
-		// Fetch git tree
-		treePath := fmt.Sprintf("repos/%s/git/trees/%s?recursive=1", key, defaultBranch)
-		treeBody, status, err := ghGet(ctx, token, treePath, &delay, &remaining, &resetAt)
-		if err != nil {
-			result.Skipped++
-			continue
-		}
-		switch status {
-		case 409: // empty repo
-			st.Repos[key] = RepoState{PushedAt: pushedAt, AmplifierLike: false}
-			result.Skipped++
-			continue
-		case 403, 404:
-			result.Skipped++
-			continue
-		}
-		if status != 200 {
-			result.Skipped++
-			continue
-		}
-
-		var treeResp struct {
-			SHA  string `json:"sha"`
-			Tree []struct {
-				Path string `json:"path"`
-			} `json:"tree"`
-		}
-		if err := json.Unmarshal(treeBody, &treeResp); err != nil {
-			result.Skipped++
-			continue
-		}
-		treeSha := treeResp.SHA
-		paths := make([]string, 0, len(treeResp.Tree))
-		for _, t := range treeResp.Tree {
-			paths = append(paths, t.Path)
-		}
-
-		// Gate 2: tree SHA unchanged
-		if treeSha != "" && cached.TreeSha == treeSha && !opts.Force {
-			st.Repos[key] = RepoState{
-				PushedAt:      pushedAt,
-				TreeSha:       cached.TreeSha,
-				AmplifierLike: cached.AmplifierLike,
-			}
-			if cached.AmplifierLike {
-				result.Unchanged++
+		case "upsert":
+			_, existed := idx.Repos[out.key]
+			idx.Repos[out.key] = *out.entry
+			if existed {
+				result.Updated = append(result.Updated, *out.entry)
+				if !opts.Quiet {
+					fmt.Printf("  ~ %s (updated)\n", out.key)
+				}
 			} else {
-				result.Skipped++
-			}
-			continue
-		}
-
-		// Check amplifier signatures
-		isAmplifier := treeIsAmplifierLike(paths)
-		st.Repos[key] = RepoState{
-			PushedAt:      pushedAt,
-			TreeSha:       treeSha,
-			AmplifierLike: isAmplifier,
-		}
-
-		if !isAmplifier {
-			if _, existed := idx.Repos[key]; existed {
-				result.Removed = append(result.Removed, key)
-				delete(idx.Repos, key)
-			} else {
-				result.Skipped++
-			}
-			continue
-		}
-
-		// Extract capabilities
-		parts := strings.SplitN(key, "/", 2)
-		ownerName, repoName := parts[0], parts[1]
-		readmeText, _ := rawFile(token, ownerName, repoName, defaultBranch, "README.md")
-		caps, _ := ExtractCapabilities(token, ownerName, repoName, defaultBranch, paths, readmeText)
-
-		name, _ := repo["name"].(string)
-		desc, _ := repo["description"].(string)
-		if desc == "" {
-			desc = readmeDescription(readmeText)
-		}
-		stars, _ := repo["stargazers_count"].(float64)
-		private, _ := repo["private"].(bool)
-
-		topicsAny, _ := repo["topics"].([]any)
-		topics := make([]string, 0, len(topicsAny))
-		for _, t := range topicsAny {
-			if s, ok := t.(string); ok {
-				topics = append(topics, s)
-			}
-		}
-
-		entry := Entry{
-			Remote:        key,
-			Name:          name,
-			Description:   desc,
-			DefaultBranch: defaultBranch,
-			Stars:         int(stars),
-			Private:       private,
-			Topics:        topics,
-			Install:       fmt.Sprintf("amplifier bundle add git+https://github.com/%s@%s", key, defaultBranch),
-			Capabilities:  caps,
-			ScannedAt:     time.Now().UTC().Format(time.RFC3339),
-		}
-
-		_, existed := idx.Repos[key]
-		idx.Repos[key] = entry
-
-		if existed {
-			result.Updated = append(result.Updated, entry)
-			if !opts.Quiet {
-				fmt.Printf("  ~ %s (updated)\n", key)
-			}
-		} else {
-			result.Added = append(result.Added, entry)
-			if !opts.Quiet {
-				fmt.Printf("  + %s\n", key)
+				result.Added = append(result.Added, *out.entry)
+				if !opts.Quiet {
+					fmt.Printf("  + %s\n", out.key)
+				}
 			}
 		}
 	}

--- a/internal/index/scanner.go
+++ b/internal/index/scanner.go
@@ -39,7 +39,8 @@ type ScanResult struct {
 // Controls which repos get scanned.
 
 type Sources struct {
-	// Remote team-JSON feeds (e.g. made-team.json from amplifier-shared).
+	// Remote team-JSON feeds. Each URL should point to a JSON file with a
+	// "team_members" array containing "gh_handle" fields (and optional "directs").
 	// Handles are extracted and each handle's repos are scanned.
 	TeamFeeds []TeamFeed `json:"team_feeds"`
 
@@ -52,10 +53,10 @@ type Sources struct {
 
 type TeamFeed struct {
 	Name string `json:"name"`
-	URL  string `json:"url"` // raw URL to a made-team.json file
+	URL  string `json:"url"` // raw URL to a team JSON file
 }
 
-// madeTeamJSON is the schema of made-team.json.
+// madeTeamJSON is the expected schema of a team feed JSON file.
 type madeTeamJSON struct {
 	TeamMembers []madeTeamMember `json:"team_members"`
 }

--- a/internal/index/scanner.go
+++ b/internal/index/scanner.go
@@ -89,7 +89,7 @@ func extractHandles(members []madeTeamMember) []string {
 
 // resolveHandles fetches all team feeds and merges with ExtraHandles.
 // Returns deduped list of GitHub handles.
-func resolveHandles(ctx context.Context, src Sources) ([]string, error) {
+func resolveHandles(ctx context.Context, token string, src Sources) ([]string, error) {
 	seen := map[string]bool{}
 	var handles []string
 
@@ -102,7 +102,7 @@ func resolveHandles(ctx context.Context, src Sources) ([]string, error) {
 	}
 
 	for _, feed := range src.TeamFeeds {
-		body, err := httpGet(ctx, feed.URL, "")
+		body, err := httpGet(ctx, feed.URL, token)
 		if err != nil {
 			return nil, fmt.Errorf("fetching team feed %q: %w", feed.Name, err)
 		}
@@ -628,7 +628,7 @@ func Scan(ctx context.Context, dir string, opts ScanOptions) (*ScanResult, error
 	if !opts.Quiet {
 		fmt.Print("Resolving team handles... ")
 	}
-	handles, err := resolveHandles(ctx, *src)
+	handles, err := resolveHandles(ctx, token, *src)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/index/store.go
+++ b/internal/index/store.go
@@ -1,0 +1,80 @@
+package index
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// DefaultDir returns the default directory for the bundle index.
+func DefaultDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".amplifier", "github-bundle-index")
+	}
+	return filepath.Join(home, ".amplifier", "github-bundle-index")
+}
+
+// LoadIndex reads index.json from dir. Returns an empty struct if the file does
+// not exist.
+func LoadIndex(dir string) (*IndexFile, error) {
+	data, err := os.ReadFile(filepath.Join(dir, "index.json"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &IndexFile{Version: 1, Repos: make(map[string]Entry)}, nil
+		}
+		return nil, err
+	}
+	var idx IndexFile
+	if err := json.Unmarshal(data, &idx); err != nil {
+		return nil, err
+	}
+	if idx.Repos == nil {
+		idx.Repos = make(map[string]Entry)
+	}
+	return &idx, nil
+}
+
+// LoadState reads state.json from dir. Returns an empty struct if the file does
+// not exist.
+func LoadState(dir string) (*StateFile, error) {
+	data, err := os.ReadFile(filepath.Join(dir, "state.json"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &StateFile{Version: 1, Repos: make(map[string]RepoState)}, nil
+		}
+		return nil, err
+	}
+	var st StateFile
+	if err := json.Unmarshal(data, &st); err != nil {
+		return nil, err
+	}
+	if st.Repos == nil {
+		st.Repos = make(map[string]RepoState)
+	}
+	return &st, nil
+}
+
+// SaveIndex marshals idx and writes it to dir/index.json, creating dir if needed.
+func SaveIndex(dir string, idx *IndexFile) error {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(idx, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "index.json"), data, 0644)
+}
+
+// SaveState marshals st and writes it to dir/state.json, creating dir if needed.
+func SaveState(dir string, st *StateFile) error {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "state.json"), data, 0644)
+}

--- a/internal/index/store.go
+++ b/internal/index/store.go
@@ -78,3 +78,36 @@ func SaveState(dir string, st *StateFile) error {
 	}
 	return os.WriteFile(filepath.Join(dir, "state.json"), data, 0644)
 }
+
+// ── Sources config ─────────────────────────────────────────────────────────────
+
+const sourcesFile = "sources.json"
+
+// LoadSources reads sources.json from dir, returning an empty Sources if absent.
+func LoadSources(dir string) (*Sources, error) {
+	path := filepath.Join(dir, sourcesFile)
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return &Sources{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var s Sources
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+// SaveSources writes sources.json to dir.
+func SaveSources(dir string, s *Sources) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, sourcesFile), append(data, '\n'), 0o644)
+}

--- a/internal/index/types.go
+++ b/internal/index/types.go
@@ -1,0 +1,52 @@
+package index
+
+// Capability describes a single capability (bundle, agent, recipe, behavior, etc.)
+// discovered in a repository.
+type Capability struct {
+	Type        string `json:"type"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Version     string `json:"version,omitempty"`
+	SourceFile  string `json:"sourceFile"`
+}
+
+// Entry is the index record for one GitHub repository.
+type Entry struct {
+	Remote        string       `json:"remote"`        // "org/repo"
+	Name          string       `json:"name"`
+	Description   string       `json:"description,omitempty"`
+	DefaultBranch string       `json:"defaultBranch"`
+	Stars         int          `json:"stars"`
+	Private       bool         `json:"private"`
+	Topics        []string     `json:"topics"`
+	Install       string       `json:"install"`
+	Capabilities  []Capability `json:"capabilities"`
+	ScannedAt     string       `json:"scannedAt"`
+}
+
+// IndexFile is the on-disk format for index.json.
+type IndexFile struct {
+	Version  int              `json:"version"`
+	LastScan string           `json:"lastScan"`
+	Repos    map[string]Entry `json:"repos"`
+}
+
+// RepoState tracks per-repo scan state for incremental updates.
+type RepoState struct {
+	PushedAt      string `json:"pushedAt"`
+	TreeSha       string `json:"treeSha"`
+	AmplifierLike bool   `json:"amplifierLike"`
+}
+
+// StateFile is the on-disk format for state.json.
+type StateFile struct {
+	Version   int                  `json:"version"`
+	Repos     map[string]RepoState `json:"repos"`
+	RateLimit *RateLimitInfo       `json:"rateLimit,omitempty"`
+}
+
+// RateLimitInfo holds the last known GitHub rate-limit state.
+type RateLimitInfo struct {
+	Remaining int   `json:"remaining"`
+	ResetAt   int64 `json:"resetAt"`
+}

--- a/packaging/macos/Info.plist
+++ b/packaging/macos/Info.plist
@@ -29,5 +29,7 @@
     <string>NSApplication</string>
     <key>NSUserNotificationUsageDescription</key>
     <string>Loom uses notifications to alert you when a meeting is detected and when transcription is ready.</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Loom records your microphone during meetings to create transcripts.</string>
 </dict>
 </plist>

--- a/packaging/macos/Info.plist
+++ b/packaging/macos/Info.plist
@@ -27,5 +27,7 @@
     <true/>
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
+    <key>NSUserNotificationUsageDescription</key>
+    <string>Loom uses notifications to alert you when a meeting is detected and when transcription is ready.</string>
 </dict>
 </plist>

--- a/ui/src/api/bundles.ts
+++ b/ui/src/api/bundles.ts
@@ -22,6 +22,16 @@ export interface RegistryEntry {
     total: number
     rating: number
   }
+  // Private / local registry fields
+  private?: boolean
+  localPath?: string
+  capabilities?: Array<{
+    type: string
+    name: string
+    description: string | null
+    version: string | null
+    sourceFile: string
+  }>
 }
 
 // ── Installed bundle types (loom config) ─────────────────────────────────────
@@ -39,6 +49,13 @@ export interface AppBundle {
 export async function fetchRegistry(): Promise<RegistryEntry[]> {
   const res = await fetch('/api/registry')
   if (!res.ok) throw new Error(await res.text())
+  return res.json()
+}
+
+/** Fetch private bundles from the local index (~/.amplifier/bundle-index/). */
+export async function fetchLocalRegistry(): Promise<RegistryEntry[]> {
+  const res = await fetch('/api/local-registry')
+  if (!res.ok) return []  // graceful degradation if index not seeded
   return res.json()
 }
 

--- a/ui/src/views/bundles/index.tsx
+++ b/ui/src/views/bundles/index.tsx
@@ -1,16 +1,19 @@
 import { useEffect, useState } from 'react'
 import {
   RegistryEntry, AppBundle,
-  fetchRegistry, listBundles, addBundle, removeBundle, toggleBundle,
+  fetchRegistry, fetchLocalRegistry, listBundles, addBundle, removeBundle, toggleBundle,
 } from '../../api/bundles'
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 const TYPE_COLORS: Record<string, string> = {
-  bundle: 'bg-[#388bfd]/20 text-[#F59E0B]',
-  agent:  'bg-[#7C3F2A]/20 text-[#7C3F2A]',
-  tool:   'bg-[#3fb950]/20 text-[#56d364]',
-  module: 'bg-[#C4784A]/20 text-[#C4784A]',
+  bundle:   'bg-[#388bfd]/20 text-[#F59E0B]',
+  agent:    'bg-[#7C3F2A]/20 text-[#7C3F2A]',
+  tool:     'bg-[#3fb950]/20 text-[#56d364]',
+  module:   'bg-[#C4784A]/20 text-[#C4784A]',
+  behavior: 'bg-[#5c2d91]/20 text-[#b392f0]',
+  recipe:   'bg-[#0d419d]/20 text-[#79c0ff]',
+  package:  'bg-[#264f78]/20 text-[#79c0ff]',
 }
 
 function Stars({ rating }: { rating: number | null }) {
@@ -52,7 +55,10 @@ function BundleCard({
           <span className="text-[9px] text-[var(--text-very-muted)]">{entry.namespace}</span>
         </div>
         <div className="flex items-center gap-1 shrink-0">
-          {entry.featured && (
+          {entry.private && (
+            <span className="text-[8px] px-1 py-0.5 rounded bg-[#30363d] text-[#8b949e]" title={entry.localPath}>🔒 private</span>
+          )}
+          {!entry.private && entry.featured && (
             <span className="text-[8px] px-1 py-0.5 rounded bg-[var(--amber-subtle)] text-[var(--amber)]">featured</span>
           )}
           <span className={`text-[9px] px-1.5 py-0.5 rounded capitalize ${TYPE_COLORS[entry.type] ?? 'bg-[var(--bg-sidebar-active)] text-[var(--text-muted)]'}`}>
@@ -122,6 +128,7 @@ function BundleCard({
 
 export default function BundlesView() {
   const [registry,  setRegistry]  = useState<RegistryEntry[]>([])
+  const [localRegistry, setLocalRegistry] = useState<RegistryEntry[]>([])
   const [installed, setInstalled] = useState<AppBundle[]>([])
   const [loading,   setLoading]   = useState(true)
   const [search,    setSearch]    = useState('')
@@ -132,8 +139,8 @@ export default function BundlesView() {
   const [error, setError]         = useState<string | null>(null)
 
   useEffect(() => {
-    Promise.all([fetchRegistry(), listBundles()])
-      .then(([reg, inst]) => { setRegistry(reg); setInstalled(inst) })
+    Promise.all([fetchRegistry(), fetchLocalRegistry(), listBundles()])
+      .then(([reg, local, inst]) => { setRegistry(reg); setLocalRegistry(local); setInstalled(inst) })
       .catch((e: unknown) => {
         console.error(e)
         setError((e as Error).message ?? 'Failed to load registry')
@@ -185,21 +192,26 @@ export default function BundlesView() {
 
   // Filter registry
   const q = search.toLowerCase()
-  const filtered = registry.filter(e => {
-    if (category !== 'all' && e.category !== category) return false
+  const matchEntry = (e: RegistryEntry) => {
     if (typeFilter !== 'all' && e.type !== typeFilter) return false
     if (q) {
       return e.name.toLowerCase().includes(q) ||
-        e.description.toLowerCase().includes(q) ||
-        e.namespace.toLowerCase().includes(q) ||
+        (e.description ?? '').toLowerCase().includes(q) ||
+        (e.namespace ?? '').toLowerCase().includes(q) ||
         (e.tags ?? []).some(t => t.toLowerCase().includes(q))
     }
     return true
+  }
+  const filtered = registry.filter(e => {
+    if (category !== 'all' && e.category !== category) return false
+    return matchEntry(e)
   })
+  const localFiltered = localRegistry.filter(matchEntry)
 
   const featured = filtered.filter(e => e.featured && !installedIds.has(e.id))
   const rest     = filtered.filter(e => !e.featured && !installedIds.has(e.id))
-  const installedEntries = filtered.filter(e => installedIds.has(e.id))
+  const installedEntries = [...filtered, ...localFiltered].filter(e => installedIds.has(e.id))
+  const privateEntries = localFiltered.filter(e => !installedIds.has(e.id))
 
   if (error) {
     return (
@@ -376,6 +388,25 @@ export default function BundlesView() {
                     key={e.id}
                     entry={e}
                     installed={true}
+                    busy={!!busy[e.id]}
+                    onAdd={() => handleAdd(e)}
+                    onRemove={() => handleRemove(e.id)}
+                  />
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Private / local */}
+          {privateEntries.length > 0 && (
+            <section>
+              <h3 className="text-[10px] text-[#8b949e] uppercase tracking-wider mb-2">🔒 Private ({privateEntries.length})</h3>
+              <div className="grid grid-cols-2 xl:grid-cols-3 gap-3">
+                {privateEntries.map(e => (
+                  <BundleCard
+                    key={e.id}
+                    entry={e}
+                    installed={installedIds.has(e.id)}
                     busy={!!busy[e.id]}
                     onAdd={() => handleAdd(e)}
                     onRemove={() => handleRemove(e.id)}


### PR DESCRIPTION
## What

Adds `make app` and `make app-sync` Makefile targets that assemble a proper macOS `.app` bundle from the built binary, ad-hoc sign it, strip quarantine, and launch it. Updates `make dev` to use this as the hot-reload mechanism via air.

## Why

loom's tray + notification features require a proper `.app` bundle with a bundle identifier (for `UNUserNotificationCenter`, `NSPanel` overlays, and macOS permission prompts). Running the raw `dist/loom` binary skips all of this.

## Changes

### `Makefile`
- `make app` — builds binary → assembles `dist/Loom.app` → ad-hoc signs → strips quarantine → launches
- `make app-sync` — fast path: drops new binary into existing `.app` → re-signs → relaunches (called by air after each Go rebuild)
- `make dev` — now bootstraps `Loom.app` on first run before starting air + vite

### `.air.toml`
- Switches from `bin = "dist/loom" args_bin = ["_serve"]` to `full_bin = "make app-sync"`
- Uses `CGO_ENABLED=1` (required for tray + CGO features)
- Version set to `99.0.0-dev` to prevent the auto-updater from clobbering the dev binary

### `packaging/macos/Info.plist`
- Adds `NSMicrophoneUsageDescription` (required for macOS to show the mic permission prompt)

## Dev workflow after this PR

```bash
make app   # first time: full build + launch
make dev   # hot-reload: .go save → rebuild → Loom.app relaunches automatically
```
